### PR TITLE
Allow CCZ & CCP in Triangular and First Device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "httpmock",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +108,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.21",
  "slab",
  "socket2",
  "waker-fn",
@@ -130,7 +145,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.37.21",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -176,7 +191,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -190,6 +205,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -243,6 +273,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -334,9 +370,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -551,7 +587,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -594,6 +630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -629,15 +671,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -715,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -791,26 +824,25 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "hermit-abi",
+ "rustix 0.38.1",
  "windows-sys 0.48.0",
 ]
 
@@ -858,9 +890,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -919,9 +951,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libm"
@@ -956,6 +988,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1006,6 +1044,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1126,11 +1173,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1150,6 +1197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,11 +1213,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1178,7 +1234,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1198,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1273,22 +1329,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "6e138fdd8263907a2b0e1b4e80b7e58c721126479b6e6eedfb1b402acea7b9bd"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1316,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -1363,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -1451,7 +1507,7 @@ dependencies = [
  "roqoqo",
  "serde",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.22",
  "thiserror",
 ]
 
@@ -1463,7 +1519,7 @@ checksum = "03411b76166a46cb3e8e2d6846cefe0c53c77f9d8469a8a4b2224121e34f2761"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1522,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1587,7 +1643,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1596,7 +1652,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1688,7 +1744,7 @@ dependencies = [
  "rand_distr",
  "roqoqo-derive",
  "serde",
- "syn 2.0.18",
+ "syn 2.0.22",
  "thiserror",
 ]
 
@@ -1700,7 +1756,7 @@ checksum = "fe0bdd70484ec44a5580ecd12ba68bca8dbfe789ca6c87464828b2c8d5355dd6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1754,8 +1810,14 @@ dependencies = [
  "quote",
  "rand",
  "roqoqo",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1765,15 +1827,28 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "62f25693a73057a1b4cb56179dd3c7ea21a7c6c5ee7d85781f5749b46f34b79c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1819,7 +1894,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1853,14 +1928,14 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2004,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2021,9 +2096,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"
@@ -2035,7 +2110,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.21",
  "windows-sys 0.48.0",
 ]
 
@@ -2089,7 +2164,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2118,11 +2193,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2142,7 +2218,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2190,13 +2266,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2276,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "vcpkg"
@@ -2300,11 +2376,10 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2316,9 +2391,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2326,24 +2401,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2353,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2363,28 +2438,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2448,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.8.7"
+version = "0.9.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -37,7 +37,7 @@ qoqo = {package="qoqo", version="1.5", default-features=false}
 roqoqo = {package="roqoqo", version="1.5", features = ["serialize"]}
 
 ndarray = "0.15"
-roqoqo-qryd = {version="0.8.7", path="../roqoqo-qryd", default-features=false, features = ["serialize"]}
+roqoqo-qryd = {version="0.9", path="../roqoqo-qryd", default-features=false, features = ["serialize"]}
 bincode = "1.3"
 serde_json = "1.0"
 

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
   'numpy',
   'qoqo>=1.5',

--- a/qoqo-qryd/python_tests/requirements.txt
+++ b/qoqo-qryd/python_tests/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 numpy
-qoqo>=1.4
-qoqo_qryd>=0.8
+qoqo>=1.5
+qoqo_qryd>=0.9

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -1,5 +1,5 @@
 ====================================================
-aho-corasick 1.0.1
+aho-corasick 1.0.2
 https://github.com/BurntSushi/aho-corasick
 by Andrew Gallant <jamslam@gmail.com>
 Fast multiple substring searching.
@@ -3462,7 +3462,7 @@ THE SOFTWARE.
 
 
 ====================================================
-base64 0.21.0
+base64 0.21.2
 https://github.com/marshallpierce/rust-base64
 by Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>
 encodes and decodes base64 as bytes or utf8
@@ -4759,7 +4759,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-bumpalo 3.12.1
+bumpalo 3.13.0
 https://github.com/fitzgen/bumpalo
 by Nick Fitzgerald <fitzgen@gmail.com>
 A fast bump allocation arena for Rust.
@@ -6626,226 +6626,6 @@ Crunchy unroller: deterministically unroll constant loops
 License: MIT
 
 ====================================================
-ctor 0.1.26
-https://github.com/mmastrac/rust-ctor
-by Matt Mastracci <matthew@mastracci.com>
-__attribute__((constructor)) for Rust
-License: Apache-2.0 OR MIT
-----------------------------------------------------
-LICENSE-APACHE:
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-----------------------------------------------------
-LICENSE-MIT:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-====================================================
 curl 0.4.44
 https://github.com/alexcrichton/curl-rust
 by Alex Crichton <alex@alexcrichton.com>
@@ -6876,7 +6656,7 @@ THE SOFTWARE.
 
 
 ====================================================
-curl-sys 0.4.61+curl-8.0.1
+curl-sys 0.4.63+curl-8.1.2
 https://github.com/alexcrichton/curl-rust
 by Alex Crichton <alex@alexcrichton.com>
 Native bindings to the libcurl library
@@ -10024,7 +9804,7 @@ SOFTWARE.
 
 
 ====================================================
-form_urlencoded 1.1.0
+form_urlencoded 1.2.0
 https://github.com/servo/rust-url
 by The rust-url developers
 Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.
@@ -12293,7 +12073,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-getrandom 0.2.9
+getrandom 0.2.10
 https://github.com/rust-random/getrandom
 by The Rand Project Developers
 A small cross-platform library for retrieving random data from system source
@@ -12542,7 +12322,7 @@ Convenience crate for working with JavaScript timers
 License: MIT/Apache-2.0
 
 ====================================================
-h2 0.3.18
+h2 0.3.19
 https://github.com/hyperium/h2
 by Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>
 An HTTP/2 client and server
@@ -14583,7 +14363,7 @@ THE SOFTWARE.
 
 
 ====================================================
-idna 0.3.0
+idna 0.4.0
 https://github.com/servo/rust-url/
 by The rust-url developers
 IDNA (Internationalizing Domain Names in Applications) and Punycode.
@@ -15317,7 +15097,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ====================================================
-io-lifetimes 1.0.10
+io-lifetimes 1.0.11
 https://github.com/sunfishcode/io-lifetimes
 by Dan Gohman <dev@sunfishcode.online>
 A low-level I/O ownership and borrowing library
@@ -16950,7 +16730,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-js-sys 0.3.61
+js-sys 0.3.63
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bindings for all JS global objects and functions in all JS environments like
@@ -17681,7 +17461,7 @@ Levenshtein algorithm
 License: MIT
 
 ====================================================
-libc 0.2.142
+libc 0.2.146
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -17898,7 +17678,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libm 0.2.6
+libm 0.2.7
 https://github.com/rust-lang/libm
 by Jorge Aparicio <jorge@japaric.io>
 libm in pure Rust
@@ -18623,7 +18403,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-linux-raw-sys 0.3.6
+linux-raw-sys 0.3.8
 https://github.com/sunfishcode/linux-raw-sys
 by Dan Gohman <dev@sunfishcode.online>
 Generated bindings for Linux's userspace API
@@ -19086,7 +18866,7 @@ Software.
 
 
 ====================================================
-lock_api 0.4.9
+lock_api 0.4.10
 https://github.com/Amanieu/parking_lot
 by Amanieu d'Antras <amanieu@gmail.com>
 Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.
@@ -19327,7 +19107,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-log 0.4.17
+log 0.4.19
 https://github.com/rust-lang/log
 by The Rust Project Developers
 A lightweight logging facade for Rust
@@ -20146,7 +19926,7 @@ THE SOFTWARE.
 
 
 ====================================================
-mio 0.8.6
+mio 0.8.8
 https://github.com/tokio-rs/mio
 by Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>
 Lightweight non-blocking I/O.
@@ -22146,7 +21926,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ====================================================
-once_cell 1.17.1
+once_cell 1.18.0
 https://github.com/matklad/once_cell
 by Aleksey Kladov <aleksey.kladov@gmail.com>
 Single assignment cells and lazy values.
@@ -22385,7 +22165,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-openssl 0.10.52
+openssl 0.10.54
 https://github.com/sfackler/rust-openssl
 by Steven Fackler <sfackler@gmail.com>
 OpenSSL bindings
@@ -22888,7 +22668,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-openssl-src 111.25.3+1.1.1t
+openssl-src 111.26.0+1.1.1u
 https://github.com/alexcrichton/openssl-src-rs
 by Alex Crichton <alex@alexcrichton.com>
 Source of OpenSSL and logic to build it.
@@ -23130,7 +22910,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-openssl-sys 0.9.87
+openssl-sys 0.9.88
 https://github.com/sfackler/rust-openssl
 by Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>
 FFI bindings to OpenSSL
@@ -23659,7 +23439,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-parking_lot_core 0.9.7
+parking_lot_core 0.9.8
 https://github.com/Amanieu/parking_lot
 by Amanieu d'Antras <amanieu@gmail.com>
 An advanced API for creating custom synchronization primitives.
@@ -24114,7 +23894,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-percent-encoding 2.2.0
+percent-encoding 2.3.0
 https://github.com/servo/rust-url/
 by The rust-url developers
 Percent encoding and decoding
@@ -24603,7 +24383,7 @@ Support code shared by PHF libraries
 License: MIT
 
 ====================================================
-pin-project 1.0.12
+pin-project 1.1.0
 https://github.com/taiki-e/pin-project
 by 
 A crate for safe and ergonomic pin-projection.
@@ -24819,7 +24599,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pin-project-internal 1.0.12
+pin-project-internal 1.1.0
 https://github.com/taiki-e/pin-project
 by 
 Implementation detail of the `pin-project` crate.
@@ -25493,7 +25273,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-pkg-config 0.3.26
+pkg-config 0.3.27
 https://github.com/rust-lang/pkg-config-rs
 by Alex Crichton <alex@alexcrichton.com>
 A library to run the pkg-config system tool at build time in order to be used in
@@ -26722,7 +26502,7 @@ SOFTWARE.
 
 
 ====================================================
-proc-macro2 1.0.56
+proc-macro2 1.0.60
 https://github.com/dtolnay/proc-macro2
 by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.
@@ -28787,7 +28567,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.8.7
+qoqo-qryd 0.9.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -29698,7 +29478,7 @@ Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================
-quote 1.0.26
+quote 1.0.28
 https://github.com/dtolnay/quote
 by David Tolnay <dtolnay@gmail.com>
 Quasi-quoting macro quote!(...)
@@ -31206,7 +30986,7 @@ SOFTWARE.
 
 
 ====================================================
-regex 1.8.1
+regex 1.8.4
 https://github.com/rust-lang/regex
 by The Rust Project Developers
 An implementation of regular expressions for Rust. This implementation uses
@@ -31690,7 +31470,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-syntax 0.7.1
+regex-syntax 0.7.2
 https://github.com/rust-lang/regex
 by The Rust Project Developers
 A regular expression parser.
@@ -31931,7 +31711,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-reqwest 0.11.17
+reqwest 0.11.18
 https://github.com/seanmonstar/reqwest
 by Sean McArthur <sean@seanmonstar.com>
 higher level HTTP client library
@@ -32590,7 +32370,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.8.7
+roqoqo-qryd 0.9.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit
@@ -33465,7 +33245,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-rustix 0.37.18
+rustix 0.37.20
 https://github.com/bytecodealliance/rustix
 by Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
 Safe Rust bindings to POSIX/Unix/Linux/Winsock2-like syscalls
@@ -34356,11 +34136,89 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-safe_arch 0.6.0
+safe_arch 0.7.0
 https://github.com/Lokathor/safe_arch
 by Lokathor <zefria@gmail.com>
 Crate that exposes `core::arch` safely via `#[cfg()]`.
 License: Zlib OR Apache-2.0 OR MIT
+----------------------------------------------------
+LICENSE-MIT.md:
+
+MIT License
+
+Copyright (c) 2023 Daniel "Lokathor" Gee.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------------------------------------------
+LICENSE-APACHE.md:
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+    2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+    3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+    4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+        (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+        (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+        (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+        (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+    5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+    6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+    7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+    8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+    9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 ----------------------------------------------------
 LICENSE-ZLIB.md:
 
@@ -34642,7 +34500,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-security-framework 2.8.2
+security-framework 2.9.1
 https://lib.rs/crates/security_framework
 by Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>
 Security.framework bindings for macOS and iOS
@@ -34878,7 +34736,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-security-framework-sys 2.8.0
+security-framework-sys 2.9.0
 https://lib.rs/crates/security-framework-sys
 by Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>
 Apple `Security.framework` low-level FFI bindings
@@ -35114,7 +34972,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde 1.0.160
+serde 1.0.164
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -35328,7 +35186,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.160
+serde_derive 1.0.164
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -36021,7 +35879,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_test 1.0.160
+serde_test 1.0.164
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Token De/Serializer for testing De/Serialize implementations
@@ -38407,7 +38265,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-syn 2.0.15
+syn 2.0.18
 https://github.com/dtolnay/syn
 by David Tolnay <dtolnay@gmail.com>
 Parser for Rust source code
@@ -38884,7 +38742,7 @@ Software.
 
 
 ====================================================
-tempfile 3.5.0
+tempfile 3.6.0
 https://stebalien.com/projects/tempfile-rs/
 by Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>
 A library for managing temporary files and directories.
@@ -40465,7 +40323,7 @@ freely, subject to the following restrictions:
 
 
 ====================================================
-tokio 1.28.0
+tokio 1.28.2
 https://tokio.rs
 by Tokio Contributors <team@tokio.rs>
 An event-driven, non-blocking I/O platform for writing asynchronous I/O
@@ -40748,7 +40606,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-tracing-core 0.1.30
+tracing-core 0.1.31
 https://tokio.rs
 by Tokio Contributors <team@tokio.rs>
 Core primitives for application-level tracing.
@@ -41338,7 +41196,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-unicode-ident 1.0.8
+unicode-ident 1.0.9
 https://github.com/dtolnay/unicode-ident
 by David Tolnay <dtolnay@gmail.com>
 Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31
@@ -42330,7 +42188,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-url 2.3.1
+url 2.4.0
 https://github.com/servo/rust-url
 by The rust-url developers
 URL library for Rust, based on the WHATWG URL Standard
@@ -42571,7 +42429,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-value-bag 1.0.0-alpha.9
+value-bag 1.4.0
 https://github.com/sval-rs/value-bag
 by Ashley Mannix <ashleymannix@live.com.au>
 Anonymous structured values
@@ -44021,7 +43879,7 @@ Software.
 
 
 ====================================================
-wasm-bindgen 0.2.84
+wasm-bindgen 0.2.86
 https://rustwasm.github.io/
 by The wasm-bindgen Developers
 Easy support for interacting between JS and Rust.
@@ -44263,7 +44121,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-backend 0.2.84
+wasm-bindgen-backend 0.2.86
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Backend code generation of the wasm-bindgen tool
@@ -44505,7 +44363,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-futures 0.4.34
+wasm-bindgen-futures 0.4.36
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bridging the gap between Rust Futures and JavaScript Promises
@@ -44746,7 +44604,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro 0.2.84
+wasm-bindgen-macro 0.2.86
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
@@ -44988,7 +44846,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro-support 0.2.84
+wasm-bindgen-macro-support 0.2.86
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate
@@ -45230,7 +45088,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-shared 0.2.84
+wasm-bindgen-shared 0.2.86
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
@@ -45473,7 +45331,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-web-sys 0.3.61
+web-sys 0.3.63
 https://rustwasm.github.io/wasm-bindgen/web-sys/index.html
 by The wasm-bindgen Developers
 Bindings for all Web APIs, a procedurally generated crate from WebIDL
@@ -45715,7 +45573,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wide 0.7.8
+wide 0.7.10
 https://github.com/Lokathor/wide
 by Lokathor <zefria@gmail.com>
 A crate to help you go wide.
@@ -46223,484 +46081,10 @@ license-apache-2.0:
 
 
 ====================================================
-windows-sys 0.45.0
-https://github.com/microsoft/windows-rs
-by Microsoft
-Rust for Windows
-License: MIT OR Apache-2.0
-----------------------------------------------------
-license-mit:
-
-    MIT License
-
-    Copyright (c) Microsoft Corporation.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
-
-----------------------------------------------------
-license-apache-2.0:
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright (c) Microsoft Corporation.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-====================================================
 windows-sys 0.48.0
 https://github.com/microsoft/windows-rs
 by Microsoft
 Rust for Windows
-License: MIT OR Apache-2.0
-----------------------------------------------------
-license-mit:
-
-    MIT License
-
-    Copyright (c) Microsoft Corporation.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
-
-----------------------------------------------------
-license-apache-2.0:
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright (c) Microsoft Corporation.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-====================================================
-windows-targets 0.42.2
-https://github.com/microsoft/windows-rs
-by Microsoft
-Import libs for Windows
 License: MIT OR Apache-2.0
 ----------------------------------------------------
 license-mit:

--- a/qoqo-qryd/src/api_devices.rs
+++ b/qoqo-qryd/src/api_devices.rs
@@ -374,10 +374,11 @@ impl QrydEmuTriangularDeviceWrapper {
     /// Args:
     ///     seed (int): Seed, if not provided will be set to 0 per default (not recommended!)
     ///     controlled_z_phase_relation (Optinal[Union[str, float]]): The String used to choose what kind of phi-theta relation
-    ///                                                 to use for the PhaseShiftedControlledZ gate
+    ///                                                 to use for the PhaseShiftedControlledZ gate.
     ///     controlled_phase_phase_relation (Optinal[Union[str, float]]): The String used to choose what kind of phi-theta relation
-    ///                                                     to use for the PhaseShiftedControlledPhase gate
-    ///
+    ///                                                     to use for the PhaseShiftedControlledPhase gate.
+    ///     allow_ccz_gate (Optional[bool]): Whether to allow ControlledControlledPauliZ operations in the device.
+    ///     allow_ccp_gate (Optional[bool]): Whether to allow ControlledControlledPhaseShift operations in the device.
     /// Returns:
     ///     QrydEmuTriangularDevice: New device
     #[new]
@@ -385,6 +386,8 @@ impl QrydEmuTriangularDeviceWrapper {
         seed: Option<usize>,
         controlled_z_phase_relation: Option<&PyAny>,
         controlled_phase_phase_relation: Option<&PyAny>,
+        allow_ccz_gate: Option<bool>,
+        allow_ccp_gate: Option<bool>,
     ) -> Self {
         let czpr = if let Some(value) = controlled_z_phase_relation {
             if convert_into_calculator_float(value).is_ok() {
@@ -415,7 +418,7 @@ impl QrydEmuTriangularDeviceWrapper {
             None
         };
         Self {
-            internal: QrydEmuTriangularDevice::new(seed, czpr, cppr),
+            internal: QrydEmuTriangularDevice::new(seed, czpr, cppr, allow_ccz_gate, allow_ccp_gate),
         }
     }
 

--- a/qoqo-qryd/src/api_devices.rs
+++ b/qoqo-qryd/src/api_devices.rs
@@ -418,7 +418,13 @@ impl QrydEmuTriangularDeviceWrapper {
             None
         };
         Self {
-            internal: QrydEmuTriangularDevice::new(seed, czpr, cppr, allow_ccz_gate, allow_ccp_gate),
+            internal: QrydEmuTriangularDevice::new(
+                seed,
+                czpr,
+                cppr,
+                allow_ccz_gate,
+                allow_ccp_gate,
+            ),
         }
     }
 

--- a/qoqo-qryd/src/qryd_devices.rs
+++ b/qoqo-qryd/src/qryd_devices.rs
@@ -66,6 +66,7 @@ impl FirstDeviceWrapper {
     ///     controlled_phase_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledPhase gate.
     /// Raises:
     ///     PyValueError
+    #[allow(clippy::too_many_arguments)]
     #[new]
     pub fn new(
         number_rows: usize,
@@ -75,6 +76,8 @@ impl FirstDeviceWrapper {
         initial_layout: PyReadonlyArray2<f64>,
         controlled_z_phase_relation: Option<&PyAny>,
         controlled_phase_phase_relation: Option<&PyAny>,
+        allow_ccz_gate: Option<bool>,
+        allow_ccp_gate: Option<bool>,
     ) -> PyResult<Self> {
         let czpr = if let Some(value) = controlled_z_phase_relation {
             if convert_into_calculator_float(value).is_ok() {
@@ -113,6 +116,8 @@ impl FirstDeviceWrapper {
                 initial_layout.as_array().to_owned(),
                 czpr,
                 cppr,
+                allow_ccz_gate,
+                allow_ccp_gate,
             )
             .map_err(|err| PyValueError::new_err(format!("{:?}", err)))?,
         })

--- a/qoqo-qryd/tests/integration/qryd_devices.rs
+++ b/qoqo-qryd/tests/integration/qryd_devices.rs
@@ -492,6 +492,8 @@ fn test_convert_to_device() {
             array![[0.0, 1.0,], [0.0, 1.0,], [0.0, 1.0]],
             None,
             None,
+            None,
+            None,
         )
         .unwrap()
         .into();
@@ -534,7 +536,7 @@ fn test_pyo3_new_change_layout() {
         let check_2: &str = check_str.split("qubit_positions").collect::<Vec<&str>>()[1]
             .split(")}")
             .collect::<Vec<&str>>()[1];
-        let comp_str = format!("FirstDeviceWrapper {{ internal: FirstDevice {{ number_rows: 3, number_columns: 2, qubit_positions: {{0: (0, 0), 1: (0, 1), 2: (1, 0), 3: (1, 1), 4: (2, 0), 5: (2, 1)}}, row_distance: 1.0, layout_register: {{0: {:?}}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\" }} }}", layout);
+        let comp_str = format!("FirstDeviceWrapper {{ internal: FirstDevice {{ number_rows: 3, number_columns: 2, qubit_positions: {{0: (0, 0), 1: (0, 1), 2: (1, 0), 3: (1, 1), 4: (2, 0), 5: (2, 1)}}, row_distance: 1.0, layout_register: {{0: {:?}}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\", allow_ccz_gate: true, allow_ccp_gate: false }} }}", layout);
         let comp_1: &str = comp_str.split("qubit_positions").collect::<Vec<&str>>()[0];
         let comp_2: &str = comp_str.split("qubit_positions").collect::<Vec<&str>>()[1]
             .split(")}")

--- a/qoqo-qryd/tests/integration/qryd_devices.rs
+++ b/qoqo-qryd/tests/integration/qryd_devices.rs
@@ -332,10 +332,20 @@ fn test_change_qubit_positions() {
 fn test_gate_times() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let original_layout = array![[0.0, 1.0,], [0.0, 1.0,], [0.0, 1.0]];
+        let original_layout = array![[0.0, 0.5,], [0.0, 0.5,], [0.0, 0.5]];
         let device_type = py.get_type::<FirstDeviceWrapper>();
         let device = device_type
-            .call1((3, 2, vec![2, 2, 2], 1.0, original_layout.to_pyarray(py)))
+            .call1((
+                3,
+                2,
+                vec![2, 2, 2],
+                0.5,
+                original_layout.to_pyarray(py),
+                Option::<&PyAny>::None,
+                Option::<&PyAny>::None,
+                true,
+                true,
+            ))
             .unwrap()
             .downcast::<PyCell<FirstDeviceWrapper>>()
             .unwrap();
@@ -351,7 +361,17 @@ fn test_gate_times() {
         assert!(two_err.is_err());
 
         let three_err = device.call_method1("three_qubit_gate_time", ("Toffoli", 0, 1, 2));
+        let three_ok_0 = device.call_method1(
+            "three_qubit_gate_time",
+            ("ControlledControlledPauliZ", 0, 1, 2),
+        );
+        let three_ok_1 = device.call_method1(
+            "three_qubit_gate_time",
+            ("ControlledControlledPhaseShift", 0, 1, 2),
+        );
         assert!(three_err.is_err());
+        assert!(three_ok_0.is_ok());
+        assert!(three_ok_1.is_ok());
 
         let mult = device.call_method1("multi_qubit_gate_time", ("MultiQubitZZ", (0, 1, 2)));
         assert!(mult.is_err());

--- a/qoqo-qryd/tests/integration/simulator_backend.rs
+++ b/qoqo-qryd/tests/integration/simulator_backend.rs
@@ -507,6 +507,8 @@ fn test_convert_to_device() {
             array![[0.0, 1.0,], [0.0, 1.0]],
             None,
             None,
+            None,
+            None,
         )
         .unwrap()
         .into();

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.8.7"
+version = "0.9.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/api_devices.rs
+++ b/roqoqo-qryd/src/api_devices.rs
@@ -1023,35 +1023,42 @@ impl Device for QrydEmuTriangularDevice {
             return None;
         }
 
-        if self
-            .two_qubit_gate_time(hqslang, control_0, target)
-            .is_some()
-            && self
-                .two_qubit_gate_time(hqslang, control_0, control_1)
-                .is_some()
-            && self
-                .two_qubit_gate_time(hqslang, control_1, target)
-                .is_some()
-        {
-            match hqslang {
-                "ControlledControlledPauliZ" => {
-                    if self.allow_ccz_gate {
-                        Some(1e-6)
-                    } else {
-                        None
-                    }
+        match hqslang {
+            "ControlledControlledPauliZ" => {
+                if self.allow_ccz_gate
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_0, target)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_0, control_1)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_1, target)
+                        .is_some()
+                {
+                    Some(1e-6)
+                } else {
+                    None
                 }
-                "ControlledControlledPhaseShift" => {
-                    if self.allow_ccp_gate {
-                        Some(1e-6)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
             }
-        } else {
-            None
+            "ControlledControlledPhaseShift" => {
+                if self.allow_ccp_gate
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_0, target)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_0, control_1)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_1, target)
+                        .is_some()
+                {
+                    Some(1e-6)
+                } else {
+                    None
+                }
+            }
+            _ => None,
         }
     }
 

--- a/roqoqo-qryd/src/qryd_devices.rs
+++ b/roqoqo-qryd/src/qryd_devices.rs
@@ -252,12 +252,12 @@ impl FirstDevice {
     ///
     /// # Arguments
     ///
-    /// `number_rows` - The fixed number of rows in device, needs to be the same for all layouts
-    /// `number_columns` - Fixed number of tweezers in each row, needs to be the same for all layouts
-    /// `qubits_per_row` - Fixed number of occupied tweezer position in each row.
+    /// * `number_rows` - The fixed number of rows in device, needs to be the same for all layouts
+    /// * `number_columns` - Fixed number of tweezers in each row, needs to be the same for all layouts
+    /// * `qubits_per_row` - Fixed number of occupied tweezer position in each row.
     ///                    At the moment assumes that number of qubits in the traps is fixed. No loading/unloading once device is created
-    /// `row_distance` - Fixed distance between rows.
-    /// `initial_layout` - The device needs at least one layout. After creation the device will be in this layout with layout number 0.
+    /// * `row_distance` - Fixed distance between rows.
+    /// * `initial_layout` - The device needs at least one layout. After creation the device will be in this layout with layout number 0.
     /// * `controlled_z_phase_relation` - The relation to use for the PhaseShiftedControlledZ gate.
     ///                                   It can be hardcoded to a specific value if a float is passed in as String.
     /// * `controlled_phase_phase_relation` - The relation to use for the PhaseShiftedControlledPhase gate.

--- a/roqoqo-qryd/src/qryd_devices.rs
+++ b/roqoqo-qryd/src/qryd_devices.rs
@@ -639,35 +639,42 @@ impl Device for FirstDevice {
             return None;
         }
 
-        if self
-            .two_qubit_gate_time(hqslang, control_0, target)
-            .is_some()
-            && self
-                .two_qubit_gate_time(hqslang, control_0, control_1)
-                .is_some()
-            && self
-                .two_qubit_gate_time(hqslang, control_1, target)
-                .is_some()
-        {
-            match hqslang {
-                "ControlledControlledPauliZ" => {
-                    if self.allow_ccz_gate {
-                        Some(1e-6)
-                    } else {
-                        None
-                    }
+        match hqslang {
+            "ControlledControlledPauliZ" => {
+                if self.allow_ccz_gate
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_0, target)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_0, control_1)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledZ", control_1, target)
+                        .is_some()
+                {
+                    Some(1e-6)
+                } else {
+                    None
                 }
-                "ControlledControlledPhaseShift" => {
-                    if self.allow_ccp_gate {
-                        Some(1e-6)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
             }
-        } else {
-            None
+            "ControlledControlledPhaseShift" => {
+                if self.allow_ccp_gate
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_0, target)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_0, control_1)
+                        .is_some()
+                    && self
+                        .two_qubit_gate_time("PhaseShiftedControlledPhase", control_1, target)
+                        .is_some()
+                {
+                    Some(1e-6)
+                } else {
+                    None
+                }
+            }
+            _ => None,
         }
     }
 

--- a/roqoqo-qryd/src/qryd_devices.rs
+++ b/roqoqo-qryd/src/qryd_devices.rs
@@ -629,16 +629,6 @@ impl Device for FirstDevice {
         control_1: &usize,
         target: &usize,
     ) -> Option<f64> {
-        if control_0 >= &30 {
-            return None;
-        }
-        if control_1 >= &30 {
-            return None;
-        }
-        if target >= &30 {
-            return None;
-        }
-
         match hqslang {
             "ControlledControlledPauliZ" => {
                 if self.allow_ccz_gate

--- a/roqoqo-qryd/src/qryd_devices.rs
+++ b/roqoqo-qryd/src/qryd_devices.rs
@@ -241,6 +241,10 @@ pub struct FirstDevice {
     controlled_phase_phase_relation: String,
     // Controls if multi_qubit_operations are present
     // multi_qubit_operations: bool,
+    /// Whether the device allows ControlledControlledPauliZ operations.
+    allow_ccz_gate: bool,
+    /// Whether the device allows ControlledControlledPhaseShift operations.
+    allow_ccp_gate: bool,
 }
 
 impl FirstDevice {
@@ -257,6 +261,9 @@ impl FirstDevice {
     /// * `controlled_z_phase_relation` - The relation to use for the PhaseShiftedControlledZ gate.
     ///                                   It can be hardcoded to a specific value if a float is passed in as String.
     /// * `controlled_phase_phase_relation` - The relation to use for the PhaseShiftedControlledPhase gate.
+    /// * `allow_ccz_gate` - Whether to allow ControlledControlledPauliZ operations in the device.
+    /// * `allow_ccp_gate` - Whether to allow ControlledControlledPhaseShift operations in the device.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         number_rows: usize,
         number_columns: usize,
@@ -265,6 +272,8 @@ impl FirstDevice {
         initial_layout: Array2<f64>,
         controlled_z_phase_relation: Option<String>,
         controlled_phase_phase_relation: Option<String>,
+        allow_ccz_gate: Option<bool>,
+        allow_ccp_gate: Option<bool>,
     ) -> Result<Self, RoqoqoBackendError> {
         if qubits_per_row.len() != number_rows {
             return Err(RoqoqoBackendError::GenericError {
@@ -301,6 +310,8 @@ impl FirstDevice {
             controlled_z_phase_relation.unwrap_or_else(|| "DefaultRelation".to_string());
         let controlled_phase_phase_relation =
             controlled_phase_phase_relation.unwrap_or_else(|| "DefaultRelation".to_string());
+        let allow_ccz_gate = allow_ccz_gate.unwrap_or(true);
+        let allow_ccp_gate = allow_ccp_gate.unwrap_or(false);
         let return_self = Self {
             number_rows,
             number_columns,
@@ -312,6 +323,8 @@ impl FirstDevice {
             controlled_z_phase_relation,
             controlled_phase_phase_relation,
             // multi_qubit_operations: true,
+            allow_ccz_gate,
+            allow_ccp_gate,
         }
         .add_layout(0, initial_layout)?;
         Ok(return_self)
@@ -564,6 +577,7 @@ impl Device for FirstDevice {
             _ => None,
         }
     }
+
     fn two_qubit_gate_time(&self, hqslang: &str, control: &usize, target: &usize) -> Option<f64> {
         // Check for availability of control and target on device
         if !self.qubit_positions().contains_key(control) {
@@ -606,6 +620,7 @@ impl Device for FirstDevice {
             Some(2e-6 * total_distance.powi(2))
         }
     }
+
     #[allow(unused_variables)]
     fn three_qubit_gate_time(
         &self,
@@ -614,8 +629,48 @@ impl Device for FirstDevice {
         control_1: &usize,
         target: &usize,
     ) -> Option<f64> {
-        None
+        if control_0 >= &30 {
+            return None;
+        }
+        if control_1 >= &30 {
+            return None;
+        }
+        if target >= &30 {
+            return None;
+        }
+
+        if self
+            .two_qubit_gate_time(hqslang, control_0, target)
+            .is_some()
+            && self
+                .two_qubit_gate_time(hqslang, control_0, control_1)
+                .is_some()
+            && self
+                .two_qubit_gate_time(hqslang, control_1, target)
+                .is_some()
+        {
+            match hqslang {
+                "ControlledControlledPauliZ" => {
+                    if self.allow_ccz_gate {
+                        Some(1e-6)
+                    } else {
+                        None
+                    }
+                }
+                "ControlledControlledPhaseShift" => {
+                    if self.allow_ccp_gate {
+                        Some(1e-6)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        }
     }
+
     #[allow(unused_variables)]
     fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
         // if !self.multi_qubit_operations {
@@ -652,6 +707,7 @@ impl Device for FirstDevice {
             None
         }
     }
+
     #[allow(unused_variables)]
     fn qubit_decoherence_rates(&self, qubit: &usize) -> Option<Array2<f64>> {
         // At the moment we hard-code a noise free model

--- a/roqoqo-qryd/tests/integration/api_backend.rs
+++ b/roqoqo-qryd/tests/integration/api_backend.rs
@@ -325,7 +325,7 @@ fn api_backend_with_constant_circuit() {
 #[test]
 fn api_triangular() {
     let number_qubits = 6;
-    let device = QrydEmuTriangularDevice::new(Some(2), None, None);
+    let device = QrydEmuTriangularDevice::new(Some(2), None, None, None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -32,7 +32,7 @@ fn test_new_square() {
 // Test the new function of the triangular device emulator
 #[test]
 fn test_new_triangular() {
-    let device = QrydEmuTriangularDevice::new(Some(1), None, None);
+    let device = QrydEmuTriangularDevice::new(Some(1), None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), 1);
     assert_eq!(device.seed(), apidevice.seed());
@@ -69,7 +69,7 @@ fn test_decoherencerates_square() {
 // Test the functions from device trait of the triangular device emulator
 #[test]
 fn test_numberqubits_triangular() {
-    let device = QrydEmuTriangularDevice::new(None, None, None);
+    let device = QrydEmuTriangularDevice::new(None, None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.number_qubits(), 30);
     assert_eq!(apidevice.number_qubits(), device.number_qubits());
@@ -78,7 +78,7 @@ fn test_numberqubits_triangular() {
 // Test the functions from device trait of the triangular device emulator
 #[test]
 fn test_decoherencerates_triangular() {
-    let device = QrydEmuTriangularDevice::new(None, None, None);
+    let device = QrydEmuTriangularDevice::new(None, None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(
         device.qubit_decoherence_rates(&0),
@@ -209,7 +209,8 @@ fn test_gatetimes_square() {
 // Test the functions from device trait of the triangular device emulator
 #[test]
 fn test_gatetimes_triangular() {
-    let device = QrydEmuTriangularDevice::new(None, None, None);
+    let device = QrydEmuTriangularDevice::new(None, None, None, Some(true), Some(true));
+    let no_3qbt_device = QrydEmuTriangularDevice::new(None, None, None, Some(false), Some(false));
     let apidevice = QRydAPIDevice::from(&device);
     // single qubit gates
     assert_eq!(device.single_qubit_gate_time("RotateXY", &0), Some(1e-6));
@@ -324,6 +325,47 @@ fn test_gatetimes_triangular() {
     );
     // three qubit gates
     assert_eq!(device.three_qubit_gate_time("Toffoli", &0, &1, &2), None);
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &6),
+        Some(1e-6)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &6),
+        apidevice.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &6)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &5, &6),
+        Some(1e-6)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &5, &6),
+        apidevice.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &5, &6)
+    );
+    assert_eq!(device.three_qubit_gate_time("Toffoli", &43, &1, &2), None);
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &62),
+        None
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &51, &6),
+        None
+    );
+    assert_eq!(
+        no_3qbt_device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &6),
+        None
+    );
+    assert_eq!(
+        no_3qbt_device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &5, &6),
+        None
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &5, &12),
+        None
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &5, &12),
+        None
+    );
     // multi qubit gates
     assert_eq!(device.multi_qubit_gate_time("MultiQubitMS", &[0, 1]), None);
     assert_eq!(
@@ -336,7 +378,7 @@ fn test_gatetimes_triangular() {
 #[test]
 fn test_gatetime_type() {
     let sq_device = QrydEmuSquareDevice::new(None, None, None);
-    let tr_device = QrydEmuTriangularDevice::new(None, None, None);
+    let tr_device = QrydEmuTriangularDevice::new(None, None, None, None, None);
 
     assert!(sq_device
         .single_qubit_gate_time("PhaseShiftState1", &0)
@@ -400,7 +442,7 @@ fn test_changedevice_square() {
 // Changing the device is not allowed for the WebAPI emulators in the current version
 #[test]
 fn test_changedevice_triangular() {
-    let mut device = QrydEmuTriangularDevice::new(None, None, None);
+    let mut device = QrydEmuTriangularDevice::new(None, None, None, None, None);
     let mut apidevice = QRydAPIDevice::from(&device);
     assert!(device.change_device("", &[]).is_err());
     assert_eq!(
@@ -472,7 +514,7 @@ fn test_twoqubitedges_square() {
 // Test the functions from device trait of the triangular device emulator
 #[test]
 fn test_twoqubitedges_triangular() {
-    let device = QrydEmuTriangularDevice::new(None, None, None);
+    let device = QrydEmuTriangularDevice::new(None, None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     let two_qubit_edges: Vec<(usize, usize)> = vec![
         (0, 1),
@@ -592,7 +634,7 @@ fn test_to_generic_device_square() {
 // Test to_generic_device() for triangular device
 #[test]
 fn test_to_generic_device_triangular() {
-    let device = QrydEmuTriangularDevice::new(Some(0), None, None);
+    let device = QrydEmuTriangularDevice::new(Some(0), None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     let genericdevice = apidevice.to_generic_device();
 
@@ -631,9 +673,10 @@ fn test_to_generic_device_triangular() {
 
 #[test]
 fn test_phi_theta_relation() {
-    let triangular = QrydEmuTriangularDevice::new(Some(0), None, None);
+    let triangular = QrydEmuTriangularDevice::new(Some(0), None, None, None, None);
     let square = QrydEmuSquareDevice::new(Some(0), None, None);
-    let triangular_f = QrydEmuTriangularDevice::new(Some(0), Some("2.13".to_string()), None);
+    let triangular_f =
+        QrydEmuTriangularDevice::new(Some(0), Some("2.13".to_string()), None, None, None);
     let square_f = QrydEmuSquareDevice::new(Some(0), Some("2.13".to_string()), None);
 
     assert_eq!(

--- a/roqoqo-qryd/tests/integration/qryd_devices.rs
+++ b/roqoqo-qryd/tests/integration/qryd_devices.rs
@@ -35,7 +35,8 @@ fn create_simple_qubit_positions(
 
 #[test]
 fn test_new_no_errors() {
-    let device = FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None).unwrap();
+    let device =
+        FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None, None, None).unwrap();
     assert_eq!(device.number_rows(), 1);
     assert_eq!(device.number_columns(), 1);
     assert_eq!(device.number_qubits(), 1);
@@ -56,6 +57,8 @@ fn test_new_error_rows() {
         &[2, 1],
         0.0,
         array![[0.0, 1.0], [0.0, 1.0]],
+        None,
+        None,
         None,
         None,
     );
@@ -79,6 +82,8 @@ fn test_new_error_columns() {
         array![[0.0, 1.0], [0.0, 1.0]],
         None,
         None,
+        None,
+        None,
     );
 
     assert!(device.is_err());
@@ -99,6 +104,8 @@ fn test_new_large() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -134,6 +141,8 @@ fn test_phi_theta_relation() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     device = device
@@ -148,6 +157,8 @@ fn test_phi_theta_relation() {
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         Some("2.13".to_string()),
+        None,
+        None,
         None,
     )
     .unwrap();
@@ -230,6 +241,8 @@ fn test_add_layout() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let new_layout: Array2<f64> = array![[0.5, 0.5, 0.5], [0.4, 0.4, 0.3]];
@@ -265,6 +278,8 @@ fn test_add_layout_error_key() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let new_layout: Array2<f64> = array![[0.5, 0.5, 0.5], [0.4, 0.4, 0.3]];
@@ -293,6 +308,8 @@ fn test_add_layout_error_rows() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let new_layout: Array2<f64> = array![[0.5, 0.5, 0.5], [0.4, 0.4, 0.4], [0.3, 0.3, 0.3]];
@@ -318,6 +335,8 @@ fn test_add_layout_error_columns() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let new_layout: Array2<f64> = array![[0.5, 0.5], [0.4, 0.4]];
@@ -341,6 +360,8 @@ fn test_switch_layout() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -391,6 +412,8 @@ fn test_switch_layout_error() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let error_device = device.switch_layout(&2);
@@ -426,6 +449,8 @@ fn test_change_qubit_positions() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let mut qryd_device: QRydDevice = QRydDevice::from(&device);
@@ -456,6 +481,8 @@ fn test_change_qubit_positions_error_qubit() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -489,6 +516,8 @@ fn test_change_qubit_positions_error_row() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let qubits = [
@@ -519,6 +548,8 @@ fn test_change_qubit_positions_error_extra_qubits() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -554,6 +585,8 @@ fn test_qubit_gate_times() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        Some(true),
+        Some(true),
     )
     .unwrap();
     device = device
@@ -603,6 +636,9 @@ fn test_qubit_gate_times() {
     assert_eq!(device.two_qubit_gate_time("ControlledPauliZ", &0, &1), None);
 
     assert_eq!(device.three_qubit_gate_time("Toffoli", &0, &1, &2), None);
+    // TODO: find correct trio
+    // assert_eq!(device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &6), Some(1e-6));
+    // assert_eq!(device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &6), Some(1e-6));
 
     assert_eq!(
         device.multi_qubit_gate_time("MultiQubitMSXX", &[0, 1, 2]),
@@ -629,6 +665,8 @@ fn test_change_device() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -687,6 +725,8 @@ fn test_qubit_edges() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     device = device
@@ -707,6 +747,8 @@ fn test_qubit_gate_times_with_layout() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -855,9 +897,12 @@ fn test_qubit_gate_times_with_layout() {
 
 #[test]
 fn test_traits_firstdevice() {
-    let device = FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None).unwrap();
-    let device_1 = FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None).unwrap();
-    let device_2 = FirstDevice::new(1, 2, &[1], 0.0, array![[0.0, 1.0],], None, None).unwrap();
+    let device =
+        FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None, None, None).unwrap();
+    let device_1 =
+        FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None, None, None).unwrap();
+    let device_2 =
+        FirstDevice::new(1, 2, &[1], 0.0, array![[0.0, 1.0],], None, None, None, None).unwrap();
 
     assert!(device == device_1);
     assert!(device_1 == device);
@@ -869,15 +914,18 @@ fn test_traits_firstdevice() {
     let qubits = create_simple_qubit_positions(&[(0_usize, (0_usize, 0_usize))]);
     assert_eq!(
         format!("{:?}", device),
-        format!("FirstDevice {{ number_rows: 1, number_columns: 1, qubit_positions: {:?}, row_distance: 0.0, layout_register: {{0: [[0.0]], shape=[1, 1], strides=[1, 1], layout=CFcf (0xf), const ndim=2}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\" }}", qubits) 
+        format!("FirstDevice {{ number_rows: 1, number_columns: 1, qubit_positions: {:?}, row_distance: 0.0, layout_register: {{0: [[0.0]], shape=[1, 1], strides=[1, 1], layout=CFcf (0xf), const ndim=2}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\", allow_ccz_gate: true, allow_ccp_gate: false }}", qubits) 
     );
 }
 
 #[test]
 fn test_traits_qryddevice() {
-    let device = FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None).unwrap();
-    let device_1 = FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None).unwrap();
-    let device_2 = FirstDevice::new(1, 2, &[1], 0.0, array![[0.0, 1.0],], None, None).unwrap();
+    let device =
+        FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None, None, None).unwrap();
+    let device_1 =
+        FirstDevice::new(1, 1, &[1], 0.0, array![[0.0,],], None, None, None, None).unwrap();
+    let device_2 =
+        FirstDevice::new(1, 2, &[1], 0.0, array![[0.0, 1.0],], None, None, None, None).unwrap();
     let qryd_device: QRydDevice = QRydDevice::from(&device);
     let qryd_device_1: QRydDevice = QRydDevice::from(&device_1);
     let qryd_device_2: QRydDevice = QRydDevice::from(&device_2);
@@ -894,7 +942,7 @@ fn test_traits_qryddevice() {
     let qubits = create_simple_qubit_positions(&[(0_usize, (0_usize, 0_usize))]);
     assert_eq!(
         format!("{:?}", qryd_device),
-        format!("FirstDevice(FirstDevice {{ number_rows: 1, number_columns: 1, qubit_positions: {:?}, row_distance: 0.0, layout_register: {{0: [[0.0]], shape=[1, 1], strides=[1, 1], layout=CFcf (0xf), const ndim=2}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\" }})", qubits) 
+        format!("FirstDevice(FirstDevice {{ number_rows: 1, number_columns: 1, qubit_positions: {:?}, row_distance: 0.0, layout_register: {{0: [[0.0]], shape=[1, 1], strides=[1, 1], layout=CFcf (0xf), const ndim=2}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\", allow_ccz_gate: true, allow_ccp_gate: false }})", qubits) 
     );
 }
 
@@ -906,6 +954,8 @@ fn test_qryd_qubit_gate_times() {
         &[3, 2],
         1.5,
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -981,6 +1031,8 @@ fn test_qryd_change_device() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     device = device
@@ -1027,6 +1079,28 @@ fn test_qryd_change_device() {
         })
     );
 }
+
+// /// Test allow_ccz_gate and allow_ccp_gate parameters
+// #[test]
+// fn test_allowed_3qubit_gate() {
+//     let device = FirstDevice::new(
+//         2,
+//         3,
+//         &[3, 2],
+//         1.5,
+//         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+//         None,
+//         None,
+//         None,
+//         None,
+//     )
+//     .unwrap();
+
+//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &33, &5, &3).is_none());
+//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &3, &53, &3).is_none());
+//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &3, &5, &38).is_none());
+
+// }
 
 // /// Test FirstDevice Serialization and Deserialization traits (readable)
 // #[cfg(feature = "serialize")]

--- a/roqoqo-qryd/tests/integration/qryd_devices.rs
+++ b/roqoqo-qryd/tests/integration/qryd_devices.rs
@@ -585,8 +585,8 @@ fn test_qubit_gate_times() {
         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
         None,
         None,
-        Some(true),
-        Some(true),
+        None,
+        None,
     )
     .unwrap();
     device = device
@@ -635,10 +635,20 @@ fn test_qubit_gate_times() {
     );
     assert_eq!(device.two_qubit_gate_time("ControlledPauliZ", &0, &1), None);
 
+    // Correct three qubit gate times are tested further down (cutoff)
     assert_eq!(device.three_qubit_gate_time("Toffoli", &0, &1, &2), None);
-    // TODO: find correct trio
-    // assert_eq!(device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &6), Some(1e-6));
-    // assert_eq!(device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &6), Some(1e-6));
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &32),
+        None
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &67, &3),
+        None
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &45, &1, &32),
+        None
+    );
 
     assert_eq!(
         device.multi_qubit_gate_time("MultiQubitMSXX", &[0, 1, 2]),
@@ -1080,27 +1090,46 @@ fn test_qryd_change_device() {
     );
 }
 
-// /// Test allow_ccz_gate and allow_ccp_gate parameters
-// #[test]
-// fn test_allowed_3qubit_gate() {
-//     let device = FirstDevice::new(
-//         2,
-//         3,
-//         &[3, 2],
-//         1.5,
-//         array![[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
-//         None,
-//         None,
-//         None,
-//         None,
-//     )
-//     .unwrap();
+/// Test allow_ccz_gate and allow_ccp_gate parameters
+#[test]
+fn test_allowed_3qubit_gate() {
+    let device = FirstDevice::new(
+        2,
+        3,
+        &[3, 2],
+        0.5,
+        array![[0.0, 0.5, 1.0], [0.0, 0.5, 1.0]],
+        None,
+        None,
+        Some(true),
+        Some(true),
+    )
+    .unwrap();
 
-//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &33, &5, &3).is_none());
-//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &3, &53, &3).is_none());
-//     assert!(device.three_qubit_gate_time("ControlledControlledPauliZ", &3, &5, &38).is_none());
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPauliZ", &33, &5, &3)
+        .is_none());
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPauliZ", &3, &53, &3)
+        .is_none());
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPauliZ", &3, &5, &38)
+        .is_none());
 
-// }
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &3)
+        .is_some());
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &3)
+        .is_some());
+
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &5)
+        .is_none());
+    assert!(device
+        .three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &5)
+        .is_none());
+}
 
 // /// Test FirstDevice Serialization and Deserialization traits (readable)
 // #[cfg(feature = "serialize")]

--- a/roqoqo-qryd/tests/integration/simulator_backend.rs
+++ b/roqoqo-qryd/tests/integration/simulator_backend.rs
@@ -28,6 +28,8 @@ fn init_backend() {
         array![[0.0, 1.0], [0.0, 1.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let _backend = SimulatorBackend::new(device.into());
@@ -46,6 +48,8 @@ fn pragma_shift_qryd_qubit_simple_traits() {
         &[1, 1],
         3.0,
         array![[0.0, 1.0], [0.0, 1.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -72,6 +76,8 @@ fn pragma_shift_qryd_qubit_simple_traits() {
         array![[0.0, 1.0], [0.0, 1.0]],
         None,
         None,
+        None,
+        None,
     )
     .unwrap()
     .add_layout(1, layout.clone())
@@ -83,6 +89,8 @@ fn pragma_shift_qryd_qubit_simple_traits() {
         &[1, 1],
         2.0,
         array![[0.0, 1.0], [0.0, 1.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -106,6 +114,8 @@ fn run_simple_circuit() {
         &[1, 1],
         3.0,
         array![[0.0, 1.0], [0.0, 1.0]],
+        None,
+        None,
         None,
         None,
     )
@@ -140,7 +150,7 @@ fn test_measurement() {
         vec![RotateY::new(0, std::f64::consts::FRAC_PI_2.into()).into()];
     let (measurement, exp_vals) =
         prepare_monte_carlo_gate_test(gate, preparation_gates, basis_rotation_gates, None, 1, 200);
-    let device = FirstDevice::new(1, 1, &[1], 3.0, array![[0.0],], None, None).unwrap();
+    let device = FirstDevice::new(1, 1, &[1], 3.0, array![[0.0],], None, None, None, None).unwrap();
     let backend = SimulatorBackend::new(device.into());
     let measured_exp_vals = backend.run_measurement(&measurement).unwrap().unwrap();
     for (key, val) in exp_vals.iter() {
@@ -165,7 +175,8 @@ fn test_full_simple_gate() {
     let (measurement, exp_vals) =
         prepare_monte_carlo_gate_test(gate, preparation_gates, basis_rotation_gates, None, 5, 200);
 
-    let device = FirstDevice::new(1, 1, &[1], 3.0, array![[0.0,],], None, None).unwrap();
+    let device =
+        FirstDevice::new(1, 1, &[1], 3.0, array![[0.0,],], None, None, None, None).unwrap();
     let backend = SimulatorBackend::new(device.into());
     let measured_exp_vals = backend.run_measurement(&measurement).unwrap().unwrap();
     for (key, val) in exp_vals.iter() {


### PR DESCRIPTION
FirstDevice and QRydEmuTriangularDevice take two additional optional parameters `allow_ccz_gate` and `allow_ccp_gate`.

If set to `true`, they return `Some(...)` for `three_qubit_gate_time` for the `ControlledControlledPauliZ` and `ControlledControlledPhaseShift` operations. Relevant checks are performed.

The default value for `allow_ccz_gate` is set to `true`, `allow_ccp_gate` is set to `false`.