### PR TITLE
Shifts from Rows, Doc Fix, Default Layout

### DIFF
--- a/.github/workflows/hqs-build-deploy-rust-pyo3.yml
+++ b/.github/workflows/hqs-build-deploy-rust-pyo3.yml
@@ -31,7 +31,7 @@ jobs:
       py_interface_folder: "qoqo-qryd"
       deploy: true
       # Whether to build for aarch64. Can fail if there are C/C++ dependencies
-      build_for_arm: true
+      build_for_arm: false
     secrets: inherit
   
   build_maturin_builds_macos:

--- a/.github/workflows/hqs-build-deploy-sphinx-doc-rust-pyo3.yml
+++ b/.github/workflows/hqs-build-deploy-sphinx-doc-rust-pyo3.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -19,16 +21,23 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin
-        pip install ./qoqo-qryd
-        python -m pip install -r ./userdoc/requirements.txt
+        pip install ./qoqo-qryd[docs]
+    - uses: peaceiris/actions-mdbook@v1
+      with:
+        version: latest
     - name: build
       run: |
-        cd ./userdoc
+        # qoqo-qryd
+        cd qoqo-qryd/docs
         python -m sphinx -T -E -b html . _build/html
-        cd ../../
+        cd ../..
+        cp -r ./qoqo-qryd/docs/_build/html ./documentation/src/qoqo_qryd_api
+        # Generating doc
+        cd documentation/
+        mdbook build
+
     - name: publish
       uses: peaceiris/actions-gh-pages@v3
-      # if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./userdoc/_build/html/
+        publish_dir: documentation/book

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.11.1
+
+* Corrected the check of the validity of a `PragmaShiftQubitsTweezers` operation for `TweezerDevice`
+* Added `TweezerDevice.set_allowed_tweezer_shifts_from_rows()`
+* Added `TweezerDevice.two_tweezer_edges()`
+* Added `TweezerDevice.set_default_layout()`
+* Added `APIBackend.set_dev()`
+* Corrected docs after mdbook port
+
 # 0.11.0
 
 * Substituted `httpmock` with `mockito` in mock testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "mockito",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "bitvec",

--- a/documentation/src/qoqo_qryd_api.md
+++ b/documentation/src/qoqo_qryd_api.md
@@ -1,7 +1,7 @@
 qoqo-qryd API documentation
 ===========================
 
-The qoqo-qryd provides software components for [qoqo](https://github.com/HQSquantumsimulations/qoqo>)  that support QRydDemo quantum computers.
+The qoqo-qryd provides software components for [qoqo](https://github.com/HQSquantumsimulations/qoqo>) that support QRydDemo quantum computers.
 
 The qoqo-qryd module provides:
 
@@ -9,4 +9,4 @@ The qoqo-qryd module provides:
 2. A set of specific operations only available on QRydDemo hardware.
 3. A collection of devices, representations of the hardware devices available in QrydDemo.
 
-This is the API documentation of qoqo-qryd, for a more general overview see the User Documentation.
+This is the [API documentation of qoqo-qryd](qoqo_qryd_api/html/index.html), for a more general overview see the User Documentation.

--- a/documentation/src/qrydspecifics.md
+++ b/documentation/src/qrydspecifics.md
@@ -11,27 +11,33 @@ Note that all functionality described here is a preview and does not represent a
 Special operations
 ------------------
 
-To support the full flexibility of the QRydDemo devices, two additional qoqo operations are provided ``PragmaChangeQRydLayout`` and ``PragmaShiftQRydQubit``.
-``PragmaChangeQRydLayout`` allows a quantum circuit to change between predefined calibrated optical tweezer positions.
-``PragmaShiftQRydQubit`` allows a quantum circuit to shift a qubit from one tweezer position to another.
+To support the full flexibility of the QRydDemo devices, two additional qoqo operations are provided ``PragmaChangeQRydLayout``, ``PragmaSwitchDeviceLayout``, ``PragmaShiftQRydQubit`` and ``PragmaShiftQubitsTweezers``.
+``PragmaChangeQRydLayout`` allows a quantum circuit to change between predefined calibrated optical tweezer positions. It indexes the layouts by integer. A similar operation, but meant for ``TweezerDevice`` and ``TweezerMutableDevice``, is ``PragmaSwitchDeviceLayout``, which indexes the new layout via a string.
+``PragmaShiftQRydQubit`` allows a quantum circuit to shift a qubit from one tweezer position to another. ``PragmaShiftQubitsTweezers`` is the equivalent operation meant to be used with ``TweezerDevice`` and ``TweezerMutableDevice``.
 
 ```python
    from qoqo import Circuit
-   from qoqo_qryd.pragma_operations import PragmaChangeQRydLayout, PragmaShiftQRydQubit
+   from qoqo_qryd.pragma_operations import PragmaChangeQRydLayout, PragmaShiftQRydQubit, PragmaSwitchDeviceLayout, PragmaShiftQubitsTweezers
+
    circuit = Circuit()
    # Switch to predefined layout 1
    circuit += PragmaChangeQRydLayout(new_layout=1).to_pragma_change_device()
+   # Switch to predefined layout "triangle"
+   circuit += PragmaSwitchDeviceLayout(new_layout="triangle").to_pragma_change_device()
    # Shift qubit 0 to tweezer position: row 0, column 1 and qubit 1 to postion row 1, column 1
    circuit += PragmaShiftQRydQubit(new_positions={0: (0,1), 1: (1,1)}).to_pragma_change_device()
+   # Shift the qubit state present in tweezer 0 to tweezer 1, and the qubit state present in tweezer 2 to tweezer 3
+   circuit += PragmaShiftQubitsTweezers(shifts=[(0, 1), (2, 3)]).to_pragma_change_device()
+   ()
 ```
 
 
-Devices
+QRyd and Tweezer devices 
 -------
 
-Each type of QRydDemo hardware or Simulator device can be represented by a Device class.
+Each type of QRydDemo hardware or Simulator device can be represented by either the QRydDevice or the TweezerDevice classes.
 The available hardware operations are defined in the devices. They save the 2D connectivity and can be queried for the availability of certain gate operations on the qubit.
-At the moment there is only an example Device class ``FirstDevice``, that can be used for simulations. More devices will be added as the hardware specifications are finalized.
+At the moment the most general example Device class is ``FirstDevice``, that can be used for simulations. Other available devices include ``TweezerMutableDevice``, which works by first defining the underlying tweezer structure and then populate it with qubits as needed. ``TweezerDevice`` works in a similar way. The main difference is it does not allow any setting of the Tweezer information. This should be obtained via the `.from_api()` call (see the [WebAPI](webapi.md) section).
 
 The fundamental gates that are available on the QRydDemo devices are the following qoqo operations: ``RotateX``, ``RotateY``, ``RotateZ``, ``RotateXY``, ``PauliX``,  ``PauliY``,  ``PauliZ``, ``PhaseShiftState1`` ,  ``SqrtPauliX``,  ``InvSqrtPauliX``, ``PhaseShiftedControlledZ`` and ``PhaseShiftedControlledPhase``.
 The single-qubit gates are assumed to be available on all qubits. 
@@ -42,10 +48,12 @@ The phase shifts can in principle be device dependent.
 The devices can optionally contain the ``controlled_z_phase_relation`` and ``controlled_phase_phase_relation`` parameters that define the phase shift relations of the two-qubit gates for the device. The first parameter can also be set explicitly by putting a string defining a float value as input.
 
 ```python
-   from qoqo_qryd import devices
+   from qoqo_qryd.qryd_devices import FirstDevice
+   from qoqo_qryd.tweezer_devices import TweezerMutableDevice
    import numpy as np
-   # create a FirstDevice
-   device = devices.FirstDevice(
+
+   # Create a FirstDevice
+   first_device = FirstDevice(
       # The number of tweezer position rows in the 2D Grid is fixed
       number_rows=2,
       # The number of tweezer position  columns in the 2D grid is also fixed
@@ -64,10 +72,40 @@ The devices can optionally contain the ``controlled_z_phase_relation`` and ``con
       # Using a string that defines a relation is also possible
       controlled_z_phase_relation="0.23",
       # The relation to use for the PhaseShiftedControlledPhase phase shift value
-      controlled_phase_phase_relation="DefaultRelation")
+      controlled_phase_phase_relation="DefaultRelation"
+   )
 
    # Print the two-qubit-operation connectivity graph of the device
-   print(device.two_qubit_edges())
+   print(first_device.two_qubit_edges())
+
+   # Create a TweezerMutableDevice
+   tweezer_device = TweezerMutableDevice(
+      # The phase shift value related to the PhaseShiftedControlledZ gate
+      # Using a string that defines a relation is also possible
+      controlled_z_phase_relation="0.23",
+      # The relation to use for the PhaseShiftedControlledPhase phase shift value
+      controlled_phase_phase_relation="DefaultRelation"
+   )
+
+   # Add a tweezer layout to the device
+   tweezer_device.add_layout(name="triangle")
+
+   # Set single-qubit tweezer gate time information on the new layout
+   tweezer_device.set_tweezer_single_qubit_gate_time(
+      hqslang="PhaseShiftState1",
+      tweezer=0,
+      gate_time=0.23,
+      layout="triangle",
+   )
+
+   # Populate the newly set tweezer with qubit indexed as 0
+   tweezer_device.add_qubit_tweezer_mapping(
+      qubit=0,
+      tweezer=0,
+   )
+
+   # Print the available layouts of the device
+   print(tweezer_device.available_layouts())
 ```
 
 
@@ -79,11 +117,11 @@ Executing a circuit with the ``SimulatorBackend`` initialized by the ``FirstDevi
 operations available in ``FirstDevice`` are used.
 
 ```python
-   from qoqo_qryd import devices
+   from qoqo_qryd.qryd_devices import FirstDevice
    from qoqo_qryd import SimulatorBackend
    import numpy as np
-   # create a FirstDevice
-   device = devices.FirstDevice(
+   # Create a FirstDevice
+   device = FirstDevice(
       # The number of tweezer position rows in the 2D Grid is fixed
       number_rows=2,
       # The number of tweezer position  columns in the 2D grid is also fixed

--- a/documentation/src/webapi.md
+++ b/documentation/src/webapi.md
@@ -105,3 +105,20 @@ The four API calls can be used to obtain a result the following way:
     # alternatively delete job
     # backend.delete_job(job_location)
 ```
+
+TweezerDevice
+----------
+
+By calling the `.from_api()` static method, an instance of the ``TweezerDevice`` class can be created with Tweezer information already set.
+
+```python
+from qoqo_qryd.tweezer_devices import TweezerDevice
+
+# Creating a new TweezerDevice instance.
+device = TweezerDevice.from_api(
+    # The name of the device to use.
+    device_name="test_device",
+    # Optional token. This is not necessary if the token is already an environment variable.
+    access_token="YOUR_QRYD_API_TOKEN"
+)
+```

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -52,6 +52,7 @@ roqoqo-qryd = { version = "0.11", path = "../roqoqo-qryd", default-features = fa
 [dev-dependencies]
 test-case = "3.0"
 mockito = { version = "1.1", default-features = false }
+serde_json = "1.0"
 
 [build-dependencies]
 pyo3-build-config = "0.19"

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
   'numpy',
   'qoqo>=1.6',

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -19662,7 +19662,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.11.0
+qoqo-qryd 0.11.1
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -23405,7 +23405,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.11.0
+roqoqo-qryd 0.11.1
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit

--- a/qoqo-qryd/qoqo_qryd/__init__.py
+++ b/qoqo-qryd/qoqo_qryd/__init__.py
@@ -20,6 +20,7 @@
     pragma_operations
     SimulatorBackend
     APIBackend
+    tweezer_devices
 
 """
 

--- a/qoqo-qryd/src/api_backend.rs
+++ b/qoqo-qryd/src/api_backend.rs
@@ -453,6 +453,15 @@ impl APIBackendWrapper {
                 )
             })
     }
+
+    /// Setter for the dev option of the APIDevice.
+    ///
+    /// Args:
+    ///     dev (bool): The boolean to set the dev option to.
+    ///
+    pub fn set_dev(&mut self, dev: bool) {
+        self.internal.set_dev(dev);
+    }
 }
 
 /// Convert generic python object to [roqoqo_qryd::APIBackend].

--- a/qoqo-qryd/src/lib.rs
+++ b/qoqo-qryd/src/lib.rs
@@ -34,16 +34,17 @@ use pyo3::wrap_pymodule;
 /// Provides devices for the QRyd quantum hardware for the qoqo quantum toolkit.
 /// Also provides qoqo PRAGMA operations specific to those devices.
 /// Includes an optional QRydSimulator backend.
-/// Furthermore, provides a collection of all QRyd devices for the WebAPI.
+/// Furthermore, provides a collection of all QRyd as well as Tweezer devices for the WebAPI.
 ///
 /// .. autosummary::
 ///     :toctree: generated/
 ///
+///     qryd_devices
 ///     api_devices
-///     APIBackend
-///     Backend
 ///     pragma_operations
-///     devices
+///     SimulatorBackend
+///     APIBackend
+///     tweezer_devices
 ///
 pub mod qryd_devices;
 pub use qryd_devices::*;
@@ -88,7 +89,7 @@ pub use api_devices::*;
 ///     Backend
 ///     pragma_operations
 ///     qryd_devices
-///     experimental_devices
+///     tweezer_devices
 ///
 ///
 #[pymodule]

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -466,6 +466,17 @@ impl TweezerDeviceWrapper {
     fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
         self.internal.two_qubit_edges()
     }
+
+    /// Returns the two tweezer edges of the device.
+    ///
+    /// And edge between two tweezer is valid only if the
+    /// PhaseShiftedControlledPhase gate can be performed.
+    ///
+    /// Returns:
+    ///     Sequence[(int, int)]: List of two tweezer edges
+    fn two_tweezer_edges(&self) -> Vec<(usize, usize)> {
+        self.internal.two_tweezer_edges()
+    }
 }
 
 /// Tweezer Mutable Device
@@ -895,6 +906,17 @@ impl TweezerMutableDeviceWrapper {
     ///     Sequence[(int, int)]: List of two qubit edges in the undirected connectivity graph
     fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
         self.internal.two_qubit_edges()
+    }
+
+    /// Returns the two tweezer edges of the device.
+    ///
+    /// And edge between two tweezer is valid only if the
+    /// PhaseShiftedControlledPhase gate can be performed.
+    ///
+    /// Returns:
+    ///     Sequence[(int, int)]: List of two tweezer edges
+    fn two_tweezer_edges(&self) -> Vec<(usize, usize)> {
+        self.internal.two_tweezer_edges()
     }
 
     /// Set the time of a single-qubit gate for a tweezer in a given Layout.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -27,6 +27,11 @@ use roqoqo_qryd::TweezerDevice;
 ///
 /// This interface does not allow setting any piece of information about the device
 /// tweezers. This class is meant to be used by the end user.
+///
+/// Args:
+///     controlled_z_phase_relation ((Optional[Union[str, float]])): The relation to use for the PhaseShiftedControlledZ gate.
+///                                   It can be hardcoded to a specific value if a float is passed in as String.
+///     controlled_phase_phase_relation ((Optional[Union[str, float]])): The relation to use for the PhaseShiftedControlledPhase gate.
 #[pyclass(name = "TweezerDevice", module = "qoqo_qryd")]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TweezerDeviceWrapper {
@@ -467,6 +472,11 @@ impl TweezerDeviceWrapper {
 ///
 /// This interface allows setting any piece of information about the device
 /// tweezer.
+///
+/// Args:
+///     controlled_z_phase_relation ((Optional[Union[str, float]])): The relation to use for the PhaseShiftedControlledZ gate.
+///                                   It can be hardcoded to a specific value if a float is passed in as String.
+///     controlled_phase_phase_relation ((Optional[Union[str, float]])): The relation to use for the PhaseShiftedControlledPhase gate.
 #[pyclass(name = "TweezerMutableDevice", module = "qoqo_qryd")]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TweezerMutableDeviceWrapper {

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1030,6 +1030,19 @@ impl TweezerMutableDeviceWrapper {
             )
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
+
+    /// Set the name of the default layout to use.
+    ///
+    /// Args:
+    ///     layout (str): The name of the layout to use.
+    ///
+    /// Raises:
+    ///     ValueError: The given layout name is not present in the layout register.
+    pub fn set_default_layout(&mut self, layout: &str) -> PyResult<()> {
+        self.internal
+            .set_default_layout(layout)
+            .map_err(|err| PyValueError::new_err(format!("{:}", err)))
+    }
 }
 
 /// Convert generic python object to [roqoqo_qryd::TweezerDevice].

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1027,7 +1027,7 @@ impl TweezerMutableDeviceWrapper {
     /// Args:
     ///     tweezer (int): The index of the tweezer.
     ///     allowed_shifts (list(list(int))): The allowed tweezer shifts.
-    ///     layout_name (Optional[str]): The name of the Layout to apply the gate time in.
+    ///     layout_name (Optional[str]): The name of the Layout to apply the allowed shifts in.
     ///         Defaults to the current Layout.
     ///
     /// Raises:
@@ -1044,6 +1044,37 @@ impl TweezerMutableDeviceWrapper {
             .set_allowed_tweezer_shifts(
                 &tweezer,
                 allowed_shifts
+                    .iter()
+                    .map(|vec| vec.as_slice())
+                    .collect::<Vec<&[usize]>>()
+                    .as_slice(),
+                layout_name,
+            )
+            .map_err(|err| PyValueError::new_err(format!("{:}", err)))
+    }
+
+    /// Set the allowed Tweezer shifts from a list of tweezers.
+    ///
+    /// The items in the rows give the allowed tweezers that qubit can be shifted into.
+    /// For a list 1,2,3 the qubit can be shifted into tweezer 1, into tweezer 2 if tweezer 1 is not occupied,
+    /// and into tweezer 3 if tweezer 1 and 2 are not occupied.
+    ///
+    /// Args:
+    ///     row_shifts (list(list(int))): A list of lists, each representing a row of tweezers.
+    ///     layout_name (Optional[str]): The name of the Layout to apply the allowed shifts in.
+    ///         Defaults to the current Layout.
+    ///
+    /// Raises:
+    ///     ValueError: The involved tweezers are not present in the device.
+    #[pyo3(text_signature = "(row_shifts, layout_name, /)")]
+    pub fn set_allowed_tweezer_shifts_from_rows(
+        &mut self,
+        row_shifts: Vec<Vec<usize>>,
+        layout_name: Option<String>,
+    ) -> PyResult<()> {
+        self.internal
+            .set_allowed_tweezer_shifts_from_rows(
+                row_shifts
                     .iter()
                     .map(|vec| vec.as_slice())
                     .collect::<Vec<&[usize]>>()

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1056,8 +1056,8 @@ impl TweezerMutableDeviceWrapper {
     /// Set the allowed Tweezer shifts from a list of tweezers.
     ///
     /// The items in the rows give the allowed tweezers that qubit can be shifted into.
-    /// For a list 1,2,3 the qubit can be shifted into tweezer 1, into tweezer 2 if tweezer 1 is not occupied,
-    /// and into tweezer 3 if tweezer 1 and 2 are not occupied.
+    /// For a row defined as 1,2,3, a qubit in tweezer 1 can be shifted into tweezer 2, 
+    /// and into tweezer 3 if tweezer 2 is not occupied by a qubit.
     ///
     /// Args:
     ///     row_shifts (list(list(int))): A list of lists, each representing a row of tweezers.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1056,7 +1056,7 @@ impl TweezerMutableDeviceWrapper {
     /// Set the allowed Tweezer shifts from a list of tweezers.
     ///
     /// The items in the rows give the allowed tweezers that qubit can be shifted into.
-    /// For a row defined as 1,2,3, a qubit in tweezer 1 can be shifted into tweezer 2, 
+    /// For a row defined as 1,2,3, a qubit in tweezer 1 can be shifted into tweezer 2,
     /// and into tweezer 3 if tweezer 2 is not occupied by a qubit.
     ///
     /// Args:

--- a/qoqo-qryd/tests/integration/api_backend.rs
+++ b/qoqo-qryd/tests/integration/api_backend.rs
@@ -790,3 +790,17 @@ fn test_bincode_square() {
         assert_eq!(backend_wrapper, serde_wrapper);
     });
 }
+
+#[test]
+fn test_dev_setter() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let backend = create_backend_with_square_device(py, Some(11));
+
+        assert!(backend.call_method1("set_dev", (true,)).is_ok());
+
+        let internal = &backend.borrow().internal;
+
+        assert!(internal.dev);
+    });
+}

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -60,12 +60,12 @@ fn test_layouts() {
         assert!(device
             .call_method0("available_layouts")
             .unwrap()
-            .contains("Default")
+            .contains("default")
             .unwrap());
         assert!(device_mut
             .call_method0("available_layouts")
             .unwrap()
-            .contains("Default")
+            .contains("default")
             .unwrap());
 
         let current_layout: String = device
@@ -79,8 +79,8 @@ fn test_layouts() {
             .extract()
             .unwrap();
 
-        assert_eq!(current_layout, "Default");
-        assert_eq!(current_layout_mut, "Default");
+        assert_eq!(current_layout, "default");
+        assert_eq!(current_layout_mut, "default");
 
         assert!(device_mut
             .call_method1("add_layout", ("OtherLayout",))
@@ -96,12 +96,12 @@ fn test_layouts() {
         assert!(device
             .call_method0("available_layouts")
             .unwrap()
-            .contains("Default")
+            .contains("default")
             .unwrap());
         assert!(device_mut
             .call_method0("available_layouts")
             .unwrap()
-            .contains("Default")
+            .contains("default")
             .unwrap());
         assert!(device
             .call_method0("available_layouts")

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -705,7 +705,7 @@ fn test_from_api() {
         .rev()
         .collect::<String>();
     let mock = server
-        .mock("POST", mockito::Matcher::Any)
+        .mock("GET", mockito::Matcher::Any)
         .with_status(200)
         .with_body(
             serde_json::to_string(&returned_device_default)

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -196,6 +196,39 @@ fn test_allowed_tweezer_shifts() {
     })
 }
 
+/// Test set_allowed_tweezer_shifts_from_rows of TweeerDeviceMutableWrapper
+#[test]
+fn test_allowed_tweezer_shifts_from_rows() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let device_type_mut = py.get_type::<TweezerMutableDeviceWrapper>();
+        let device_mut = device_type_mut.call0().unwrap();
+
+        device_mut
+            .call_method1("set_tweezer_single_qubit_gate_time", ("PauliX", 0, 0.23))
+            .unwrap();
+        device_mut
+            .call_method1("set_tweezer_single_qubit_gate_time", ("PauliX", 1, 0.23))
+            .unwrap();
+        device_mut
+            .call_method1("set_tweezer_single_qubit_gate_time", ("PauliX", 2, 0.23))
+            .unwrap();
+
+        assert!(device_mut
+            .call_method1(
+                "set_allowed_tweezer_shifts_from_rows",
+                (vec![vec![0, 1, 2]],)
+            )
+            .is_ok());
+        assert!(device_mut
+            .call_method1("set_allowed_tweezer_shifts_from_rows", (vec![vec![1, 5]],))
+            .is_err());
+        assert!(device_mut
+            .call_method1("set_allowed_tweezer_shifts_from_rows", (vec![vec![0, 0]],))
+            .is_err());
+    })
+}
+
 /// Test deactivate_qubit function of TweezerDeviceWrapper and TweezerMutableDeviceWrapper
 #[test]
 fn test_deactivate_qubit() {

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -13,6 +13,7 @@
 //! Integration test for Tweezer Devices
 
 use pyo3::{prelude::*, types::PyDict};
+#[cfg(feature = "web-api")]
 use serde_json::Value;
 
 use qoqo_qryd::{

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -49,6 +49,8 @@ pub struct APIBackend {
     timeout: usize,
     /// The address of the Mock server, used for testing purposes.
     mock_port: Option<String>,
+    /// Is develop version. Defaults to `false`.
+    pub dev: bool,
 }
 
 /// Local struct representing the body of the request message
@@ -353,6 +355,7 @@ impl APIBackend {
                 access_token: "".to_string(),
                 timeout: timeout.unwrap_or(30),
                 mock_port,
+                dev: false,
             })
         } else {
             let access_token_internal: String = match access_token {
@@ -369,6 +372,7 @@ impl APIBackend {
                 access_token: access_token_internal,
                 timeout: timeout.unwrap_or(30),
                 mock_port,
+                dev: false,
             })
         }
     }
@@ -412,7 +416,7 @@ impl APIBackend {
         let data = QRydRunData {
             backend: self.device.qrydbackend(),
             program: quantumprogram,
-            dev: false,
+            dev: self.dev,
             fusion_max_qubits: 4,
             seed_simulator: Some(seed_param),
             seed_compiler: None,
@@ -758,6 +762,16 @@ impl APIBackend {
         }
         bit_map.insert(readout, measurement_record);
         Ok((bit_map, float_map, complex_map))
+    }
+
+    /// Setter for the dev option of the APIDevice.
+    ///
+    /// # Arguments
+    ///
+    /// * `dev` - The boolean to set the dev option to.
+    ///
+    pub fn set_dev(&mut self, dev: bool) {
+        self.dev = dev;
     }
 }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -216,7 +216,7 @@ impl TweezerDevice {
         mock_port: Option<String>,
     ) -> Result<Self, RoqoqoBackendError> {
         // Preparing variables
-        let device_name_internal = device_name.unwrap_or_else(|| String::from("Default"));
+        let device_name_internal = device_name.unwrap_or_else(|| String::from("default"));
         let access_token_internal: String = if mock_port.is_some() {
             "".to_string()
         } else {
@@ -249,7 +249,7 @@ impl TweezerDevice {
         // Response gathering
         let resp = if let Some(port) = mock_port {
             client
-                .post(format!("http://127.0.0.1:{}", port))
+                .get(format!("http://127.0.0.1:{}", port))
                 .body(device_name_internal)
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
@@ -257,9 +257,11 @@ impl TweezerDevice {
                 })?
         } else {
             client
-                .post("https://api.qryddemo.itp3.uni-stuttgart.de/v2_0/get_device")
+                .get(format!(
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/v1_0/backends/devices/{}",
+                    device_name_internal
+                ))
                 .header("X-API-KEY", access_token_internal)
-                .body(device_name_internal)
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
                     msg: format!("{:?}", e),

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -583,11 +583,6 @@ impl TweezerDevice {
         let layout_name = layout_name
             .clone()
             .unwrap_or_else(|| self.current_layout.clone());
-        if self.layout_register.get(&layout_name).is_none() {
-            return Err(RoqoqoBackendError::GenericError {
-                msg: "The chosen layout has not been set.".to_string(),
-            });
-        }
 
         // Check that all the involved tweezers exist
         if row_shifts.iter().any(|s| {

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -943,9 +943,15 @@ impl TweezerDevice {
             end_tweezer: &usize,
             shift_lists: &[Vec<usize>],
         ) -> bool {
-            let correct_shift_list = shift_lists.iter().find(|list| list.contains(end_tweezer)).unwrap();
+            let correct_shift_list = shift_lists
+                .iter()
+                .find(|list| list.contains(end_tweezer))
+                .unwrap();
             // Check the path up to the target tweezer
-            for el in correct_shift_list.iter().take_while(|tw| *tw != end_tweezer) {
+            for el in correct_shift_list
+                .iter()
+                .take_while(|tw| *tw != end_tweezer)
+            {
                 if _is_tweezer_occupied(qbt_to_twz, el) {
                     return false;
                 }
@@ -969,7 +975,10 @@ impl TweezerDevice {
             {
                 Some(allowed_shifts) => {
                     if !_is_tweezer_in_shift_lists(shift_end, allowed_shifts)
-                        || !_is_tweezer_occupied(self.qubit_to_tweezer.as_ref().unwrap(), shift_start)
+                        || !_is_tweezer_occupied(
+                            self.qubit_to_tweezer.as_ref().unwrap(),
+                            shift_start,
+                        )
                         || !_is_path_free(
                             self.qubit_to_tweezer.as_ref().unwrap(),
                             shift_end,

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -175,7 +175,7 @@ impl TweezerDevice {
         controlled_phase_phase_relation: Option<String>,
     ) -> Self {
         let mut layout_register: HashMap<String, TweezerLayoutInfo> = HashMap::new();
-        layout_register.insert(String::from("Default"), TweezerLayoutInfo::default());
+        layout_register.insert(String::from("default"), TweezerLayoutInfo::default());
         let controlled_z_phase_relation =
             controlled_z_phase_relation.unwrap_or_else(|| "DefaultRelation".to_string());
         let controlled_phase_phase_relation =
@@ -184,7 +184,7 @@ impl TweezerDevice {
         TweezerDevice {
             qubit_to_tweezer: None,
             layout_register,
-            current_layout: String::from("Default"),
+            current_layout: String::from("default"),
             controlled_z_phase_relation,
             controlled_phase_phase_relation,
         }

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -585,14 +585,21 @@ impl TweezerDevice {
             .unwrap_or_else(|| self.current_layout.clone());
 
         // Check that all the involved tweezers exist
-        if row_shifts.iter().any(|s| {
-            s.iter()
+        if row_shifts.iter().any(|row| {
+            row.iter()
                 .any(|t| !self.is_tweezer_present(*t, Some(layout_name.clone())))
         }) {
             return Err(RoqoqoBackendError::GenericError {
-                msg: "The given tweezer, or shifts tweezers, are not present in the device Tweezer data."
-                    .to_string(),
+                msg: "A given Tweezer is not present in the device Tweezer data.".to_string(),
             });
+        }
+        // Check that there are no repetitions in the input shifts
+        for row in row_shifts.iter() {
+            if row.iter().duplicates().count() > 0 {
+                return Err(RoqoqoBackendError::GenericError {
+                    msg: "The given Tweezers contain repetitions.".to_string(),
+                });
+            }
         }
 
         let allowed_shifts = &mut self

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -197,9 +197,57 @@ fn test_qubit_tweezer_mapping() {
     assert_eq!(add_01.unwrap(), vec![(0, 1), (2, 3)].into_iter().collect());
 }
 
+/// Test TweezerDevice set_allowed_tweezer_shifts_from_rows() method
+#[test]
+fn test_allowed_tweezer_shifts_from_rows() {
+    let mut device = TweezerDevice::new(None, None);
+    device.add_layout("triangle").unwrap();
+    device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.0, Some("triangle".to_string()));
+    device.set_tweezer_single_qubit_gate_time("PauliX", 1, 0.0, Some("triangle".to_string()));
+    device.set_tweezer_single_qubit_gate_time("PauliX", 2, 0.0, Some("triangle".to_string()));
+    device.set_tweezer_single_qubit_gate_time("PauliX", 3, 0.0, Some("triangle".to_string()));
+    device.set_tweezer_single_qubit_gate_time("PauliX", 4, 0.0, Some("triangle".to_string()));
+    device.set_tweezer_single_qubit_gate_time("PauliX", 5, 0.0, Some("triangle".to_string()));
+
+    assert!(device
+        .set_allowed_tweezer_shifts_from_rows(
+            &[&[0, 1, 2], &[3, 4, 5]],
+            Some("triangle".to_string())
+        )
+        .is_ok());
+
+    let saved_shifts = &device
+        .layout_register
+        .get("triangle")
+        .unwrap()
+        .allowed_tweezer_shifts;
+    assert!(!saved_shifts.is_empty());
+    assert!(saved_shifts.contains_key(&0));
+    assert!(saved_shifts.get(&0).unwrap().contains(&vec![1, 2]));
+    assert!(saved_shifts.get(&1).unwrap().contains(&vec![0]));
+    assert!(saved_shifts.get(&1).unwrap().contains(&vec![2]));
+    assert!(saved_shifts.get(&2).unwrap().contains(&vec![1, 0]));
+    assert!(saved_shifts.get(&3).unwrap().contains(&vec![4, 5]));
+    assert!(saved_shifts.get(&4).unwrap().contains(&vec![3]));
+    assert!(saved_shifts.get(&4).unwrap().contains(&vec![5]));
+    assert!(saved_shifts.get(&5).unwrap().contains(&vec![4, 3]));
+
+    let incorrect_tweezer =
+        device.set_allowed_tweezer_shifts_from_rows(&[&[9]], Some("triangle".to_string()));
+    assert!(incorrect_tweezer.is_err());
+    assert_eq!(
+        incorrect_tweezer.unwrap_err(),
+        RoqoqoBackendError::GenericError {
+            msg:
+                "The given tweezer, or shifts tweezers, are not present in the device Tweezer data."
+                    .to_string(),
+        }
+    );
+}
+
 /// Test TweezerDevice set_allowed_tweezer_shifts() method
 #[test]
-fn test_allowed_tweezer_shifts() {
+fn test_allowed_tweezer_shifts_row() {
     let mut device = TweezerDevice::new(None, None);
     device.add_layout("OtherLayout").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.0, Some("OtherLayout".to_string()));

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -504,7 +504,7 @@ fn test_from_api() {
         .rev()
         .collect::<String>();
     let mut mock = server
-        .mock("POST", mockito::Matcher::Any)
+        .mock("GET", mockito::Matcher::Any)
         .with_status(200)
         .with_body(
             serde_json::to_string(&returned_device_default)
@@ -522,7 +522,7 @@ fn test_from_api() {
 
     mock.remove();
     mock = server
-        .mock("POST", mockito::Matcher::Any)
+        .mock("GET", mockito::Matcher::Any)
         .with_status(400)
         .create();
 

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -27,10 +27,10 @@ use mockito::Server;
 fn test_new() {
     let device = TweezerDevice::new(None, None);
 
-    assert_eq!(device.current_layout, "Default");
+    assert_eq!(device.current_layout, "default");
     assert!(device.qubit_to_tweezer.is_none());
     assert_eq!(device.layout_register.len(), 1);
-    assert!(device.layout_register.get("Default").is_some());
+    assert!(device.layout_register.get("default").is_some());
 }
 
 // Test TweezerDevice add_layout(), switch_layout() methods
@@ -38,14 +38,14 @@ fn test_new() {
 fn test_layouts() {
     let mut device = TweezerDevice::new(None, None);
 
-    assert!(device.available_layouts().contains(&"Default"));
+    assert!(device.available_layouts().contains(&"default"));
 
     device.add_layout("Test").unwrap();
 
     assert!(device.add_layout("Test").is_err());
 
     assert_eq!(device.layout_register.len(), 2);
-    assert!(device.layout_register.contains_key("Default"));
+    assert!(device.layout_register.contains_key("default"));
     assert!(device.layout_register.contains_key("Test"));
 
     device.set_tweezer_single_qubit_gate_time("RotateX", 0, 0.23, None);
@@ -63,7 +63,7 @@ fn test_layouts() {
         Some("Test".to_string()),
     );
 
-    let default_layout = device.layout_register.get("Default").unwrap();
+    let default_layout = device.layout_register.get("default").unwrap();
     let test_layout = device.layout_register.get("Test").unwrap();
     assert!(default_layout
         .tweezer_single_qubit_gate_times
@@ -160,7 +160,7 @@ fn test_layouts() {
         0.13
     );
 
-    assert_eq!(device.current_layout, "Default");
+    assert_eq!(device.current_layout, "default");
     assert!(device.qubit_to_tweezer.is_none());
 
     device.switch_layout("Test").unwrap();
@@ -170,7 +170,7 @@ fn test_layouts() {
 
     assert!(device.switch_layout("Error").is_err());
 
-    assert!(device.available_layouts().contains(&"Default"));
+    assert!(device.available_layouts().contains(&"default"));
     assert!(device.available_layouts().contains(&"Test"));
 }
 
@@ -414,7 +414,7 @@ fn test_change_device() {
     assert!(device
         .change_device("PragmaChangeQRydLayout", &Vec::<u8>::new())
         .is_err());
-    assert_eq!(device.current_layout, "Default");
+    assert_eq!(device.current_layout, "default");
     assert!(device
         .change_device("PragmaChangeQRydLayout", &serialize(&pragma_old_c).unwrap())
         .is_err());

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -592,6 +592,7 @@ fn test_phi_theta_relation() {
         .is_none());
 }
 
+// Test TweezerDevice two_tweezer_edges() method
 #[test]
 fn test_two_tweezer_edges() {
     let mut device = TweezerDevice::new(None, None);
@@ -608,4 +609,16 @@ fn test_two_tweezer_edges() {
         .two_tweezer_edges()
         .iter()
         .all(|el| [(0, 1), (0, 2), (1, 3), (2, 3)].contains(el)));
+}
+
+#[test]
+fn test_default_layout() {
+    let mut device = TweezerDevice::new(None, None);
+    device.add_layout("triangle").unwrap();
+    device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, Some("triangle".to_string()));
+
+    assert!(device.set_default_layout("square").is_err());
+
+    assert!(device.set_default_layout("triangle").is_ok());
+    assert_eq!(device.default_layout, Some("triangle".to_string()));
 }

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -238,9 +238,7 @@ fn test_allowed_tweezer_shifts_from_rows() {
     assert_eq!(
         incorrect_tweezer.unwrap_err(),
         RoqoqoBackendError::GenericError {
-            msg:
-                "The given tweezer, or shifts tweezers, are not present in the device Tweezer data."
-                    .to_string(),
+            msg: "A given Tweezer is not present in the device Tweezer data.".to_string(),
         }
     );
 }


### PR DESCRIPTION
* Corrected the check of the validity of a `PragmaShiftQubitsTweezers` operation for `TweezerDevice`
* Added `TweezerDevice.set_allowed_tweezer_shifts_from_rows()`
* Added `TweezerDevice.two_tweezer_edges()`
* Added `TweezerDevice.set_default_layout()`
* Added `APIBackend.set_dev()`
* Corrected docs after mdbook port