### PR TITLE
Small Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.11.3
 
-* Modified `TweezerDevice.from_json()` to automatically switch the layout of the device if a default one was set
+* Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
 
 # 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Tracks qoqo-qryd changes after 0.5
 # 0.11.3
 
 * Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
+* Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
 
 # 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Tracks qoqo-qryd changes after 0.5
 * Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
 * Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
 * Added `TweezerDevice.from_mutable()` static method
+* Added `dev` parameter in `APIBackend` constructor
 
 # 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Tracks qoqo-qryd changes after 0.5
 * Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
 * Added `TweezerDevice.from_mutable()` static method
 * Added `dev` parameter in `APIBackend` constructor
+* Added `TweezerDevice` support for `APIBackend`
 
 # 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Tracks qoqo-qryd changes after 0.5
 # 0.11.3
 
 * Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
-* Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
+* Modified `TweezerDevice` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
 * Added `TweezerDevice.from_mutable()` static method
 * Added `dev` parameter in `APIBackend` constructor
 * Added `TweezerDevice` support for `APIBackend`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Tracks qoqo-qryd changes after 0.5
 
 * Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
 * Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
+* Added `TweezerDevice.from_mutable()` static method
 
 # 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.11.3
+
+* Modified `TweezerDevice.from_json()` to automatically switch the layout of the device if a default one was set
+
 # 0.11.2
 
 * Modified `APIBackend.post_job()` to substitute `PragmaRepeatedMeasurement` into `MeasureQubit` and `PragmaSetNumberOfMeasurements` instances

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +335,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "hermit-abi"
@@ -429,12 +445,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -442,6 +458,12 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "inventory"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
 
 [[package]]
 name = "ipnet"
@@ -513,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -734,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_derive",
 ]
@@ -798,6 +820,7 @@ checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
 dependencies = [
  "cfg-if",
  "indoc",
+ "inventory",
  "libc",
  "memoffset",
  "num-complex",
@@ -853,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "qoqo"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d64554326213dd40982c27ea007adb4aef94ec5e295390d7f668d0d8796954"
+checksum = "6348fdb820ba16927418cdf5368c1a5d52bd11fdfb6393f0f9e998d3ee5d8065"
 dependencies = [
  "bincode",
  "ndarray",
@@ -872,15 +895,17 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "struqture",
+ "struqture-py",
  "syn 2.0.37",
  "thiserror",
 ]
 
 [[package]]
 name = "qoqo-macros"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0fd6270390b66e95cd487802c34dc0eba20353658bf63f9e175a6eff1331d6e"
+checksum = "f31f71e03276b5a5381d74ee3d77f23e528d1e9ec40b2cecbb88665bd5dbc62f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -889,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "bincode",
  "mockito",
@@ -935,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "quest-sys"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4ed2c062cea5068f389e771159eb7c6b1a05df42ac17c3f980870b01c577d2"
+checksum = "9b1d328ec20766c4269234fd9607be7e414ce6ddb1dfb4423b60c3cdf53b6519"
 dependencies = [
  "cc",
 ]
@@ -1014,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1026,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1043,9 +1068,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64",
  "bytes",
@@ -1069,6 +1094,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1097,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c583b334ce600522d014315553b84515afdc4fad06ac38ad2c36d1f669f48fa"
+checksum = "302b7db9cf1e9e264ec07e09fe5bc22ffd142f9dac0f73335d7197ddc778255f"
 dependencies = [
  "bincode",
  "nalgebra",
@@ -1120,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-derive"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d7454c6351b99bb865e33fa237591fb837b78f85703ab39d7e35d777a10c20"
+checksum = "29d9c82a1720f928bb19df60c57864d56efabcb9aec416bc00f2b22e9267ea55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1131,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "bincode",
  "bitvec",
@@ -1154,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-quest"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14159673b64ec13e0754fa5fa34b057866cf144bbcad39879553465d980be18e"
+checksum = "1808fd7452453a2e63be78620df4f52f10179ddea73a4b4e742d5d67e52068ea"
 dependencies = [
  "ndarray",
  "num-complex",
@@ -1169,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-test"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392e9ccd2c830e66caf14bb5e5e86b94aee7fcfb7796e43acfacade2e7145c96"
+checksum = "977c118d6958be1cde7a90b40af0f633704a70df0b01c9cd5551d9031013c21e"
 dependencies = [
  "nalgebra",
  "ndarray",
@@ -1431,6 +1457,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "struqture-py"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90d640d2456ec86f77d43374acf35899c51b631148c3696fcbe0f75c2425ac0"
+dependencies = [
+ "bincode",
+ "num-complex",
+ "numpy",
+ "proc-macro2",
+ "pyo3",
+ "pyo3-build-config",
+ "qoqo_calculator",
+ "qoqo_calculator_pyo3",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "struqture",
+ "struqture-py-macros",
+ "syn 2.0.37",
+ "thiserror",
+]
+
+[[package]]
+name = "struqture-py-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e6eb21aac68cfad86ff1fdf74fa29613f6347534f8525deb530aaf49de3999"
+dependencies = [
+ "num-complex",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1512,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1776,9 +1859,9 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "wide"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
+checksum = "ebecebefc38ff1860b4bc47550bbfa63af5746061cf0d29fcd7fa63171602598"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
   'numpy',
   'qoqo>=1.6',

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -2684,6 +2684,488 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
+core-foundation 0.9.3
+https://github.com/servo/core-foundation-rs
+by The Servo Project Developers
+Bindings to Core Foundation for macOS
+License: MIT / Apache-2.0
+----------------------------------------------------
+LICENSE-APACHE:
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----------------------------------------------------
+LICENSE-MIT:
+
+Copyright (c) 2012-2013 Mozilla Foundation
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+====================================================
+core-foundation-sys 0.8.4
+https://github.com/servo/core-foundation-rs
+by The Servo Project Developers
+Bindings to Core Foundation for macOS
+License: MIT / Apache-2.0
+----------------------------------------------------
+LICENSE-APACHE:
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----------------------------------------------------
+LICENSE-MIT:
+
+Copyright (c) 2012-2013 Mozilla Foundation
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+====================================================
 dyn-clone 1.0.14
 https://github.com/dtolnay/dyn-clone
 by David Tolnay <dtolnay@gmail.com>
@@ -7365,7 +7847,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-hashbrown 0.14.0
+hashbrown 0.14.1
 https://github.com/rust-lang/hashbrown
 by Amanieu d'Antras <amanieu@gmail.com>
 A Rust port of Google's SwissTable hash map
@@ -9618,7 +10100,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-indexmap 2.0.0
+indexmap 2.0.2
 https://github.com/bluss/indexmap
 by 
 A hash table with consistent order and fast iteration.
@@ -9863,6 +10345,220 @@ indoc 1.0.9
 https://github.com/dtolnay/indoc
 by David Tolnay <dtolnay@gmail.com>
 Indented document literals
+License: MIT OR Apache-2.0
+----------------------------------------------------
+LICENSE-APACHE:
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+----------------------------------------------------
+LICENSE-MIT:
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+====================================================
+inventory 0.3.12
+https://github.com/dtolnay/inventory
+by David Tolnay <dtolnay@gmail.com>
+Typed distributed plugin registration
 License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
@@ -12180,10 +12876,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-memchr 2.6.3
+memchr 2.6.4
 https://github.com/BurntSushi/memchr
 by Andrew Gallant <jamslam@gmail.com>, bluss
-Safe interface to memchr.
+Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for
+1, 2 or 3 byte search and single substring search.
+
 License: Unlicense OR MIT
 ----------------------------------------------------
 LICENSE-MIT:
@@ -18998,7 +19696,7 @@ LICENSE:
 
 
 ====================================================
-qoqo 1.6.2
+qoqo 1.7.0
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Quantum computing circuit toolkit. Python interface of roqoqo
@@ -19210,7 +19908,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-macros 1.6.2
+qoqo-macros 1.7.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the qoqo crate
 License: Apache-2.0
@@ -19421,7 +20119,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.11.2
+qoqo-qryd 0.11.3
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -20057,7 +20755,7 @@ LICENSE:
 
 
 ====================================================
-quest-sys 0.11.1
+quest-sys 0.11.2
 https://github.com/HQSquantumsimulations/qoqo-quest
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Bindings to the QuEST quantum computer simulator C library
@@ -21774,7 +22472,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex 1.9.5
+regex 1.9.6
 https://github.com/rust-lang/regex
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 An implementation of regular expressions for Rust. This implementation uses
@@ -22017,7 +22715,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-automata 0.3.8
+regex-automata 0.3.9
 https://github.com/rust-lang/regex/tree/master/regex-automata
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 Automata construction and matching using regular expressions.
@@ -22499,7 +23197,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-reqwest 0.11.20
+reqwest 0.11.22
 https://github.com/seanmonstar/reqwest
 by Sean McArthur <sean@seanmonstar.com>
 higher level HTTP client library
@@ -22741,7 +23439,7 @@ by Brian Smith <brian@briansmith.org>
 Safe, fast, small crypto using Rust.
 
 ====================================================
-roqoqo 1.6.2
+roqoqo 1.7.0
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Rust Quantum Computing Toolkit by HQS
@@ -22953,7 +23651,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-derive 1.6.2
+roqoqo-derive 1.7.0
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the roqoqo crate
 License: Apache-2.0
@@ -23164,7 +23862,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.11.2
+roqoqo-qryd 0.11.3
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit
@@ -23376,7 +24074,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-quest 0.11.1
+roqoqo-quest 0.11.2
 https://github.com/HQSquantumsimulations/qoqo-quest
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QuEST simulator for the qoqo quantum computing toolkit
@@ -23588,7 +24286,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-test 1.6.2
+roqoqo-test 1.7.0
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Testing helper functions for roqoqo toolkit
@@ -28727,6 +29425,223 @@ LICENSE:
 
 
 ====================================================
+struqture-py 1.5.0
+by HQS Quantum Simulations <info@quantumsimulations.de>
+Python interface of struqture, the HQS tool for representing operators, Hamiltonians and open systems.
+License: Apache-2.0
+
+====================================================
+struqture-py-macros 1.5.0
+by HQS Quantum Simulations <info@quantumsimulations.de>
+Macros for struqture-py crate.
+License: Apache-2.0
+----------------------------------------------------
+LICENSE:
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2023 HQS Quantum Simulations GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+====================================================
 syn 1.0.109
 https://github.com/dtolnay/syn
 by David Tolnay <dtolnay@gmail.com>
@@ -29178,6 +30093,20 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
+
+====================================================
+system-configuration 0.5.1
+https://github.com/mullvad/system-configuration-rs
+by Mullvad VPN
+Bindings to SystemConfiguration framework for macOS
+License: MIT OR Apache-2.0
+
+====================================================
+system-configuration-sys 0.5.0
+https://github.com/mullvad/system-configuration-rs
+by Mullvad VPN
+Low level bindings to SystemConfiguration framework for macOS
+License: MIT OR Apache-2.0
 
 ====================================================
 tap 1.0.1
@@ -34936,7 +35865,7 @@ one at http://mozilla.org/MPL/2.0/.
 
 
 ====================================================
-wide 0.7.11
+wide 0.7.12
 https://github.com/Lokathor/wide
 by Lokathor <zefria@gmail.com>
 A crate to help you go wide.

--- a/qoqo-qryd/src/api_backend.rs
+++ b/qoqo-qryd/src/api_backend.rs
@@ -71,14 +71,15 @@ impl APIBackendWrapper {
         access_token: Option<String>,
         timeout: Option<usize>,
         mock_port: Option<String>,
+        dev: Option<bool>,
     ) -> PyResult<Self> {
         let device: QRydAPIDevice = convert_into_device(device).map_err(|err| {
             PyTypeError::new_err(format!("Device Parameter is not QRydAPIDevice {:?}", err))
         })?;
         Ok(Self {
-            internal: APIBackend::new(device, access_token, timeout, mock_port).map_err(|err| {
-                PyRuntimeError::new_err(format!("No access token found {:?}", err))
-            })?,
+            internal: APIBackend::new(device, access_token, timeout, mock_port, dev).map_err(
+                |err| PyRuntimeError::new_err(format!("No access token found {:?}", err)),
+            )?,
         })
     }
 
@@ -490,11 +491,12 @@ mod test {
     #[test]
     fn debug_and_clone() {
         let device: QRydAPIDevice = QrydEmuSquareDevice::new(None, None, None).into();
-        let backend = APIBackend::new(device.clone(), Some("".to_string()), Some(2), None).unwrap();
+        let backend =
+            APIBackend::new(device.clone(), Some("".to_string()), Some(2), None, None).unwrap();
         let wrapper = APIBackendWrapper { internal: backend };
         let a = format!("{:?}", wrapper);
         assert!(a.contains("QrydEmuSquareDevice"));
-        let backend2 = APIBackend::new(device, Some("a".to_string()), Some(2), None).unwrap();
+        let backend2 = APIBackend::new(device, Some("a".to_string()), Some(2), None, None).unwrap();
         let wrapper2 = APIBackendWrapper { internal: backend2 };
         assert_eq!(wrapper.clone(), wrapper);
         assert_ne!(wrapper, wrapper2);

--- a/qoqo-qryd/src/api_backend.rs
+++ b/qoqo-qryd/src/api_backend.rs
@@ -60,7 +60,8 @@ impl APIBackendWrapper {
     ///               In synchronous operation the WebAPI is queried every 30 seconds until it has
     ///               been queried `timeout` times.
     ///     mock_port (Optional[str]): Server port to be used for testing purposes.
-    ///
+    ///     dev (Optional[bool]): The boolean to set the dev option to.
+    /// 
     /// Raises:
     ///     TypeError: Device Parameter is not QRydAPIDevice
     ///     RuntimeError: No access token found

--- a/qoqo-qryd/src/api_backend.rs
+++ b/qoqo-qryd/src/api_backend.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 /// For simulations of the QRyd quantum computer use the Backend simulator [crate::Backend].
 ///
 #[pyclass(name = "APIBackend", module = "qoqo_qryd")]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct APIBackendWrapper {
     /// Internal storage of [roqoqo_qryd::APIBackend]
     pub internal: APIBackend,
@@ -61,7 +61,7 @@ impl APIBackendWrapper {
     ///               been queried `timeout` times.
     ///     mock_port (Optional[str]): Server port to be used for testing purposes.
     ///     dev (Optional[bool]): The boolean to set the dev option to.
-    /// 
+    ///
     /// Raises:
     ///     TypeError: Device Parameter is not QRydAPIDevice
     ///     RuntimeError: No access token found

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -44,14 +44,18 @@ impl TweezerDeviceWrapper {
     /// Creates a new TweezerDevice instance.
     ///
     /// Args:
+    ///     seed (int): Seed, if not provided will be set to 0 per default (not recommended!)
     ///     controlled_z_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledZ gate.
     ///     controlled_phase_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledPhase gate.
     ///
     /// Returns:
     ///     TweezerDevice: The new TweezerDevice instance.
     #[new]
-    #[pyo3(text_signature = "(controlled_z_phase_relation, controlled_phase_phase_relation, /)")]
+    #[pyo3(
+        text_signature = "(seed, controlled_z_phase_relation, controlled_phase_phase_relation, /)"
+    )]
     pub fn new(
+        seed: Option<usize>,
         controlled_z_phase_relation: Option<&PyAny>,
         controlled_phase_phase_relation: Option<&PyAny>,
     ) -> Self {
@@ -84,7 +88,7 @@ impl TweezerDeviceWrapper {
             None
         };
         Self {
-            internal: TweezerDevice::new(czpr, cppr),
+            internal: TweezerDevice::new(seed, czpr, cppr),
         }
     }
 
@@ -509,6 +513,16 @@ impl TweezerDeviceWrapper {
     fn two_tweezer_edges(&self) -> Vec<(usize, usize)> {
         self.internal.two_tweezer_edges()
     }
+
+    /// Returns the backend associated with the device.
+    pub fn qrydbackend(&self) -> String {
+        self.internal.qrydbackend.clone()
+    }
+
+    /// Returns the seed usized for the API.
+    pub fn seed(&self) -> usize {
+        self.internal.seed
+    }
 }
 
 /// Tweezer Mutable Device
@@ -532,14 +546,18 @@ impl TweezerMutableDeviceWrapper {
     /// Creates a new TweezerMutableDevice instance.
     ///
     /// Args:
+    ///     seed (int): Seed, if not provided will be set to 0 per default (not recommended!)
     ///     controlled_z_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledZ gate.
     ///     controlled_phase_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledPhase gate.
     ///
     /// Returns:
     ///     TweezerMutableDevice: The new TweezerMutableDevice instance.
     #[new]
-    #[pyo3(text_signature = "(controlled_z_phase_relation, controlled_phase_phase_relation, /)")]
+    #[pyo3(
+        text_signature = "(seed, controlled_z_phase_relation, controlled_phase_phase_relation, /)"
+    )]
     pub fn new(
+        seed: Option<usize>,
         controlled_z_phase_relation: Option<&PyAny>,
         controlled_phase_phase_relation: Option<&PyAny>,
     ) -> Self {
@@ -572,7 +590,7 @@ impl TweezerMutableDeviceWrapper {
             None
         };
         Self {
-            internal: TweezerDevice::new(czpr, cppr),
+            internal: TweezerDevice::new(seed, czpr, cppr),
         }
     }
 
@@ -964,6 +982,16 @@ impl TweezerMutableDeviceWrapper {
     ///     Sequence[(int, int)]: List of two tweezer edges
     fn two_tweezer_edges(&self) -> Vec<(usize, usize)> {
         self.internal.two_tweezer_edges()
+    }
+
+    /// Returns the backend associated with the device.
+    pub fn qrydbackend(&self) -> String {
+        self.internal.qrydbackend.clone()
+    }
+
+    /// Returns the seed usized for the API.
+    pub fn seed(&self) -> usize {
+        self.internal.seed
     }
 
     /// Set the time of a single-qubit gate for a tweezer in a given Layout.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -447,7 +447,7 @@ impl TweezerDeviceWrapper {
             Ok(serialized)
         } else {
             Err(PyValueError::new_err(
-                "The device does not allow any valid gate in any layout. ".to_owned() +
+                "The device does not have valid QRyd gates available.".to_owned() +
                 "The valid gates are RotateXY, PhaseShiftState1 and PhaseShiftedControlledPhase.",
             ))
         }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -469,9 +469,9 @@ impl TweezerDeviceWrapper {
         let mut internal: TweezerDevice = serde_json::from_str(input)
             .map_err(|_| PyValueError::new_err("Input cannot be deserialized to TweezerDevice"))?;
         if let Some(layout) = &internal.default_layout {
-            internal
+            let _ = internal
                 .switch_layout(&layout.to_string())
-                .expect("Internal error: switching to default layout failed");
+                .map_err(|err| PyValueError::new_err(format!("{:}", err)));
         }
         Ok(TweezerDeviceWrapper { internal })
     }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -516,12 +516,12 @@ impl TweezerDeviceWrapper {
 
     /// Returns the backend associated with the device.
     pub fn qrydbackend(&self) -> String {
-        self.internal.qrydbackend.clone()
+        self.internal.qrydbackend()
     }
 
     /// Returns the seed usized for the API.
     pub fn seed(&self) -> usize {
-        self.internal.seed
+        self.internal.seed()
     }
 }
 
@@ -986,12 +986,12 @@ impl TweezerMutableDeviceWrapper {
 
     /// Returns the backend associated with the device.
     pub fn qrydbackend(&self) -> String {
-        self.internal.qrydbackend.clone()
+        self.internal.qrydbackend()
     }
 
     /// Returns the seed usized for the API.
     pub fn seed(&self) -> usize {
-        self.internal.seed
+        self.internal.seed()
     }
 
     /// Set the time of a single-qubit gate for a tweezer in a given Layout.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -438,7 +438,7 @@ impl TweezerDeviceWrapper {
         if let Some(layout) = &internal.default_layout {
             internal
                 .switch_layout(&layout.to_string())
-                .expect("Internal error, switching to default layout failed");
+                .expect("Internal error: switching to default layout failed");
         }
         Ok(TweezerDeviceWrapper { internal })
     }
@@ -1088,6 +1088,8 @@ impl TweezerMutableDeviceWrapper {
     }
 
     /// Set the name of the default layout to use.
+    ///
+    /// Additionally, switch to the layout.
     ///
     /// Args:
     ///     layout (str): The name of the layout to use.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -433,11 +433,14 @@ impl TweezerDeviceWrapper {
     #[staticmethod]
     #[pyo3(text_signature = "(input, /)")]
     fn from_json(input: &str) -> PyResult<TweezerDeviceWrapper> {
-        Ok(TweezerDeviceWrapper {
-            internal: serde_json::from_str(input).map_err(|_| {
-                PyValueError::new_err("Input cannot be deserialized to TweezerDevice")
-            })?,
-        })
+        let mut internal: TweezerDevice = serde_json::from_str(input)
+            .map_err(|_| PyValueError::new_err("Input cannot be deserialized to TweezerDevice"))?;
+        if let Some(layout) = &internal.default_layout {
+            internal
+                .switch_layout(&layout.to_string())
+                .expect("Internal error, switching to default layout failed");
+        }
+        Ok(TweezerDeviceWrapper { internal })
     }
 
     /// Return number of qubits in device.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -88,6 +88,20 @@ impl TweezerDeviceWrapper {
         }
     }
 
+    /// Creates a new TweezerDevice instance from a TweezerMutableDevice instance.
+    ///
+    /// Args:
+    ///     device (TweezerMutableDevice): The TweezerMutableDevice instance.
+    ///
+    /// Returns:
+    ///     TweezerDevice: The new TweezerDevice instance.
+    #[staticmethod]
+    #[pyo3(text_signature = "(device, /)")]
+    fn from_mutable(device: Py<PyAny>) -> PyResult<Self> {
+        let rust_dev = TweezerMutableDeviceWrapper::from_pyany(device)?;
+        Ok(Self { internal: rust_dev })
+    }
+
     /// Creates a new TweezerDevice instance containing populated tweezer data.
     ///
     /// This requires a valid QRYD_API_TOKEN. Visit `https://thequantumlaend.de/get-access/` to get one.
@@ -1130,6 +1144,34 @@ impl TweezerMutableDeviceWrapper {
         self.internal
             .set_default_layout(layout)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
+    }
+}
+
+impl TweezerMutableDeviceWrapper {
+    /// Extracts a TweezerDevice from a TweezerDeviceWrapper python object.
+    ///
+    /// # Arguments:
+    ///
+    /// `input` - The Python object that should be casted to a [roqoqo_qryd::TweezerDevice]
+    pub fn from_pyany(input: Py<PyAny>) -> PyResult<TweezerDevice> {
+        Python::with_gil(|py| -> PyResult<TweezerDevice> {
+            let input = input.as_ref(py);
+            if let Ok(try_downcast) = input.extract::<TweezerMutableDeviceWrapper>() {
+                Ok(try_downcast.internal)
+            } else {
+                Err(PyTypeError::new_err(
+                    "Input cannot be converted to a TweezerMutableDevice instance.",
+                ))
+            }
+        })
+    }
+}
+
+impl From<TweezerMutableDeviceWrapper> for TweezerDeviceWrapper {
+    fn from(mutable: TweezerMutableDeviceWrapper) -> Self {
+        Self {
+            internal: mutable.internal,
+        }
     }
 }
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -447,7 +447,7 @@ impl TweezerDeviceWrapper {
             Ok(serialized)
         } else {
             Err(PyValueError::new_err(
-                "The device does not have valid QRyd gates available.".to_owned() +
+                "The device does not have valid QRyd gates available. ".to_owned() +
                 "The valid gates are RotateXY, PhaseShiftState1 and PhaseShiftedControlledPhase.",
             ))
         }
@@ -1159,9 +1159,7 @@ impl TweezerMutableDeviceWrapper {
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
-    /// Set the name of the default layout to use.
-    ///
-    /// Additionally, switch to the layout.
+    /// Set the name of the default layout to use and switch to it.
     ///
     /// Args:
     ///     layout (str): The name of the layout to use.

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -691,7 +691,7 @@ fn test_to_from_json() {
         assert_eq!(
             serialised_empty.unwrap_err().to_string(),
             PyValueError::new_err(
-                "The device does not allow any valid gate in any layout. ".to_owned() +
+                "The device does not have valid QRyd gates available. ".to_owned() +
                 "The valid gates are RotateXY, PhaseShiftState1 and PhaseShiftedControlledPhase.",
             ).to_string()
         );

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -39,6 +39,32 @@ fn test_new() {
     })
 }
 
+/// Test from_mutable() of TweezerDeviceWrapper
+#[test]
+fn test_from_mutable() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let device_type = py.get_type::<TweezerDeviceWrapper>();
+        let device_type_mut = py.get_type::<TweezerMutableDeviceWrapper>();
+        let device_mut = device_type_mut.call0().unwrap();
+
+        device_mut
+            .call_method1("add_layout", ("triangle",))
+            .unwrap();
+
+        let dev = device_type.call_method1("from_mutable", (device_mut,));
+
+        assert!(dev.is_ok());
+        assert!(dev
+            .unwrap()
+            .call_method0("available_layouts")
+            .unwrap()
+            .extract::<Vec<String>>()
+            .unwrap()
+            .contains(&"triangle".to_string()))
+    })
+}
+
 /// Test available_ switch_ and add_layout methods of TweezerDeviceWrapper and TweezerMutableDeviceWrapper
 #[test]
 fn test_layouts() {

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -550,23 +550,33 @@ fn test_to_from_json() {
         let device_mut = device_type_mut.call0().unwrap();
 
         device_mut
-            .call_method1("set_tweezer_single_qubit_gate_time", ("RotateZ", 0, 0.23))
+            .call_method1("add_layout", ("Triangle",))
+            .unwrap();
+        device_mut
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateZ", 0, 0.23, "Triangle"),
+            )
             .unwrap();
         device_mut
             .call_method1(
                 "set_tweezer_two_qubit_gate_time",
-                ("PhaseShiftedControlledPhase", 0, 1, 0.13),
+                ("PhaseShiftedControlledPhase", 0, 1, 0.13, "Triangle"),
             )
             .unwrap();
         device_mut
             .call_method1(
                 "set_tweezer_three_qubit_gate_time",
-                ("ControlledControlledPhaseShift", 0, 1, 2, 0.13),
+                ("ControlledControlledPhaseShift", 0, 1, 2, 0.13, "Triangle"),
             )
             .unwrap();
 
         device_mut
-            .call_method1("set_allowed_tweezer_shifts", (0, vec![vec![1]]))
+            .call_method1("set_allowed_tweezer_shifts", (0, vec![vec![1]], "Triangle"))
+            .unwrap();
+
+        device_mut
+            .call_method1("set_default_layout", ("Triangle",))
             .unwrap();
 
         let serialised = device.call_method0("to_json").unwrap();
@@ -600,6 +610,15 @@ fn test_to_from_json() {
         let device_wrapper_mut = device_mut.extract::<TweezerMutableDeviceWrapper>().unwrap();
         assert_eq!(device_wrapper, serde_wrapper);
         assert_eq!(device_wrapper_mut, serde_wrapper_mut);
+
+        let device_from_mut = device_type.call0().unwrap();
+        let deserialized_dev_from_mut_dev = device_from_mut
+            .call_method1("from_json", (serialised_mut,))
+            .unwrap();
+        let device_from_mut_wrapper = deserialized_dev_from_mut_dev
+            .extract::<TweezerDeviceWrapper>()
+            .unwrap();
+        assert_eq!(device_from_mut_wrapper.current_layout(), "Triangle");
     });
 }
 

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -1045,5 +1045,14 @@ fn test_default_layout() {
         assert!(device_mut
             .call_method1("set_default_layout", ("triangle",))
             .is_ok());
+
+        assert_eq!(
+            device_mut
+                .call_method0("current_layout")
+                .unwrap()
+                .extract::<String>()
+                .unwrap(),
+            "triangle"
+        );
     })
 }

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -344,6 +344,7 @@ impl APIBackend {
     ///               In synchronous operation the WebAPI is queried every 30 seconds until it has
     ///               been queried `timeout` times.
     /// * `mock_port` - Server port to be used for testing purposes.
+    /// * `dev` - The boolean to set the dev option to.
     ///
     pub fn new(
         device: QRydAPIDevice,

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -39,7 +39,7 @@ use std::{thread, time};
 /// This limitation is introduced by design to check the compatability of quantum programs with a model of the QRyd hardware.
 /// For simulations of the QRyd quantum computer use the backend simulator [crate::Backend].
 ///
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct APIBackend {
     /// Device representing the model of a QRyd device.
     pub device: QRydAPIDevice,

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -350,6 +350,7 @@ impl APIBackend {
         access_token: Option<String>,
         timeout: Option<usize>,
         mock_port: Option<String>,
+        dev: Option<bool>,
     ) -> Result<Self, RoqoqoBackendError> {
         if mock_port.is_some() {
             Ok(Self {
@@ -374,7 +375,7 @@ impl APIBackend {
                 access_token: access_token_internal,
                 timeout: timeout.unwrap_or(30),
                 mock_port,
-                dev: false,
+                dev: dev.unwrap_or(false),
             })
         }
     }
@@ -945,10 +946,11 @@ mod test {
     #[test]
     fn debug_and_clone() {
         let device: QRydAPIDevice = QrydEmuSquareDevice::new(None, None, None).into();
-        let backend = APIBackend::new(device.clone(), Some("".to_string()), Some(2), None).unwrap();
+        let backend =
+            APIBackend::new(device.clone(), Some("".to_string()), Some(2), None, None).unwrap();
         let a = format!("{:?}", backend);
         assert!(a.contains("QrydEmuSquareDevice"));
-        let backend2 = APIBackend::new(device, Some("a".to_string()), Some(2), None).unwrap();
+        let backend2 = APIBackend::new(device, Some("a".to_string()), Some(2), None, None).unwrap();
         assert_eq!(backend.clone(), backend);
         assert_ne!(backend, backend2);
     }
@@ -1066,7 +1068,7 @@ mod test {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -1151,7 +1153,7 @@ mod test {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -1218,7 +1220,7 @@ mod test {
             .collect::<String>();
         let device = QrydEmuSquareDevice::new(Some(1), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
 
         let mut input_circuit = Circuit::new();
         input_circuit += operations::DefinitionBit::new("ro".to_string(), 3, true);

--- a/roqoqo-qryd/src/api_devices.rs
+++ b/roqoqo-qryd/src/api_devices.rs
@@ -36,7 +36,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.qrydbackend(),
             Self::QrydEmuTriangularDevice(x) => x.qrydbackend(),
-            Self::TweezerDevice(x) => x.qrydbackend.clone(),
+            Self::TweezerDevice(x) => x.qrydbackend(),
         }
     }
 
@@ -45,7 +45,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.seed(),
             Self::QrydEmuTriangularDevice(x) => x.seed(),
-            Self::TweezerDevice(x) => x.seed,
+            Self::TweezerDevice(x) => x.seed(),
         }
     }
 

--- a/roqoqo-qryd/src/api_devices.rs
+++ b/roqoqo-qryd/src/api_devices.rs
@@ -10,7 +10,7 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::phi_theta_relation;
+use crate::{phi_theta_relation, TweezerDevice};
 use ndarray::Array2;
 use roqoqo::devices::{Device, GenericDevice};
 use roqoqo::RoqoqoBackendError;
@@ -18,13 +18,15 @@ use std::str::FromStr;
 
 /// Collection of all QRyd devices for WebAPI.
 ///
-/// At the moment only contains a square and a triangular device.
-#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+/// It contains a square and a triangular device, as well the tweezer device.
+#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum QRydAPIDevice {
     /// Square Device
     QrydEmuSquareDevice(QrydEmuSquareDevice),
     /// Triangular Device
     QrydEmuTriangularDevice(QrydEmuTriangularDevice),
+    /// Tweezer Device
+    TweezerDevice(TweezerDevice),
 }
 
 /// Implements the trait to return field values of the QRydAPIDevice.
@@ -34,6 +36,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.qrydbackend(),
             Self::QrydEmuTriangularDevice(x) => x.qrydbackend(),
+            Self::TweezerDevice(x) => x.qrydbackend.clone(),
         }
     }
 
@@ -42,6 +45,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.seed(),
             Self::QrydEmuTriangularDevice(x) => x.seed(),
+            Self::TweezerDevice(x) => x.seed,
         }
     }
 
@@ -50,6 +54,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.phase_shift_controlled_z(),
             Self::QrydEmuTriangularDevice(x) => x.phase_shift_controlled_z(),
+            Self::TweezerDevice(x) => x.phase_shift_controlled_z(),
         }
     }
 
@@ -58,6 +63,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.phase_shift_controlled_phase(theta),
             Self::QrydEmuTriangularDevice(x) => x.phase_shift_controlled_phase(theta),
+            Self::TweezerDevice(x) => x.phase_shift_controlled_phase(theta),
         }
     }
 
@@ -66,6 +72,7 @@ impl QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(x) => x.gate_time_controlled_z(control, target, phi),
             Self::QrydEmuTriangularDevice(x) => x.gate_time_controlled_z(control, target, phi),
+            Self::TweezerDevice(x) => x.gate_time_controlled_z(control, target, phi),
         }
     }
 
@@ -84,6 +91,7 @@ impl QRydAPIDevice {
             Self::QrydEmuTriangularDevice(x) => {
                 x.gate_time_controlled_phase(control, target, phi, theta)
             }
+            Self::TweezerDevice(x) => x.gate_time_controlled_phase(control, target, phi, theta),
         }
     }
 }
@@ -108,6 +116,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.single_qubit_gate_time(hqslang, qubit),
             Self::QrydEmuTriangularDevice(d) => d.single_qubit_gate_time(hqslang, qubit),
+            Self::TweezerDevice(d) => d.single_qubit_gate_time(hqslang, qubit),
         }
     }
 
@@ -128,6 +137,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.two_qubit_gate_time(hqslang, control, target),
             Self::QrydEmuTriangularDevice(d) => d.two_qubit_gate_time(hqslang, control, target),
+            Self::TweezerDevice(d) => d.two_qubit_gate_time(hqslang, control, target),
         }
     }
 
@@ -159,6 +169,9 @@ impl Device for QRydAPIDevice {
             Self::QrydEmuTriangularDevice(d) => {
                 d.three_qubit_gate_time(hqslang, control_0, control_1, target)
             }
+            Self::TweezerDevice(d) => {
+                d.three_qubit_gate_time(hqslang, control_0, control_1, target)
+            }
         }
     }
 
@@ -178,6 +191,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.multi_qubit_gate_time(hqslang, qubits),
             Self::QrydEmuTriangularDevice(d) => d.multi_qubit_gate_time(hqslang, qubits),
+            Self::TweezerDevice(d) => d.multi_qubit_gate_time(hqslang, qubits),
         }
     }
 
@@ -203,6 +217,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.qubit_decoherence_rates(qubit),
             Self::QrydEmuTriangularDevice(d) => d.qubit_decoherence_rates(qubit),
+            Self::TweezerDevice(d) => d.qubit_decoherence_rates(qubit),
         }
     }
 
@@ -216,6 +231,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.number_qubits(),
             Self::QrydEmuTriangularDevice(d) => d.number_qubits(),
+            Self::TweezerDevice(d) => d.number_qubits(),
         }
     }
 
@@ -235,6 +251,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.change_device(hqslang, operation),
             Self::QrydEmuTriangularDevice(d) => d.change_device(hqslang, operation),
+            Self::TweezerDevice(d) => d.change_device(hqslang, operation),
         }
     }
 
@@ -259,6 +276,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.two_qubit_edges(),
             Self::QrydEmuTriangularDevice(d) => d.two_qubit_edges(),
+            Self::TweezerDevice(d) => d.two_qubit_edges(),
         }
     }
 
@@ -280,6 +298,7 @@ impl Device for QRydAPIDevice {
         match self {
             Self::QrydEmuSquareDevice(d) => d.to_generic_device(),
             Self::QrydEmuTriangularDevice(d) => d.to_generic_device(),
+            Self::TweezerDevice(d) => d.to_generic_device(),
         }
     }
 }
@@ -305,6 +324,18 @@ impl From<&QrydEmuTriangularDevice> for QRydAPIDevice {
 impl From<QrydEmuTriangularDevice> for QRydAPIDevice {
     fn from(input: QrydEmuTriangularDevice) -> Self {
         Self::QrydEmuTriangularDevice(input)
+    }
+}
+
+impl From<&TweezerDevice> for QRydAPIDevice {
+    fn from(input: &TweezerDevice) -> Self {
+        Self::TweezerDevice(input.clone())
+    }
+}
+
+impl From<TweezerDevice> for QRydAPIDevice {
+    fn from(input: TweezerDevice) -> Self {
+        Self::TweezerDevice(input)
     }
 }
 

--- a/roqoqo-qryd/src/api_devices.rs
+++ b/roqoqo-qryd/src/api_devices.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 
 /// Collection of all QRyd devices for WebAPI.
 ///
-/// It contains a square and a triangular device, as well the tweezer device.
+/// Contains a square device, a triangular device, and a tweezer device.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum QRydAPIDevice {
     /// Square Device

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -656,8 +656,7 @@ impl TweezerDevice {
             });
         }
         self.default_layout = Some(layout.to_string());
-        self.switch_layout(layout)
-            .expect("Internal error: switching to default layout failed");
+        self.switch_layout(layout)?;
         Ok(())
     }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -636,13 +636,15 @@ impl TweezerDevice {
 
     /// Set the name of the default layout to use.
     ///
+    /// Additionally, switch to the layout.
+    ///
     /// # Arguments
     ///
     /// * `layout` - The name of the layout to use.
     ///
     /// # Returns
     ///
-    /// * `Ok(())` - The default layout has been set.
+    /// * `Ok(())` - The default layout has been set and switched to.
     /// * `Err(RoqoqoBackendError)` - The given layout name is not present in the layout register.
     pub fn set_default_layout(&mut self, layout: &str) -> Result<(), RoqoqoBackendError> {
         if !self.layout_register.contains_key(layout) {
@@ -651,6 +653,8 @@ impl TweezerDevice {
             });
         }
         self.default_layout = Some(layout.to_string());
+        self.switch_layout(layout)
+            .expect("Internal error: switching to default layout failed");
         Ok(())
     }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -48,9 +48,7 @@ pub struct TweezerDevice {
     /// The default layout to use at first intantiation.
     pub default_layout: Option<String>,
     /// Seed, if not provided will be set to 0 per default (not recommended!)
-    pub seed: usize,
-    /// The backend associated with the device.
-    pub qrydbackend: String,
+    seed: usize,
 }
 
 /// Tweezers information relative to a Layout
@@ -197,7 +195,6 @@ impl TweezerDevice {
             controlled_phase_phase_relation,
             default_layout: None,
             seed: seed.unwrap_or_default(),
-            qrydbackend: "qryd_tweezer_device".to_string(),
         }
     }
 
@@ -1005,6 +1002,16 @@ impl TweezerDevice {
             }
         }
         true
+    }
+
+    /// Returns the seed usized for the API.
+    pub fn seed(&self) -> usize {
+        self.seed
+    }
+
+    /// Returns the backend associated with the device.
+    pub fn qrydbackend(&self) -> String {
+        "qryd_tweezer_device".to_string()
     }
 }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -167,7 +167,7 @@ impl TweezerDevice {
     ///
     /// # Arguments
     ///
-    /// * `seed` - Seed, if not provided will be set to 0 per default (not recommended!)
+    /// * `seed` - Seed, if not provided will be set to 0 by default (not recommended!)
     /// * `controlled_z_phase_relation` - The relation to use for the PhaseShiftedControlledZ gate.
     ///                                   It can be hardcoded to a specific value if a float is passed in as String.
     /// * `controlled_phase_phase_relation` - The relation to use for the PhaseShiftedControlledPhase gate.

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -47,6 +47,10 @@ pub struct TweezerDevice {
     pub controlled_phase_phase_relation: String,
     /// The default layout to use at first intantiation.
     pub default_layout: Option<String>,
+    /// Seed, if not provided will be set to 0 per default (not recommended!)
+    pub seed: usize,
+    /// The backend associated with the device.
+    pub qrydbackend: String,
 }
 
 /// Tweezers information relative to a Layout
@@ -165,6 +169,7 @@ impl TweezerDevice {
     ///
     /// # Arguments
     ///
+    /// * `seed` - Seed, if not provided will be set to 0 per default (not recommended!)
     /// * `controlled_z_phase_relation` - The relation to use for the PhaseShiftedControlledZ gate.
     ///                                   It can be hardcoded to a specific value if a float is passed in as String.
     /// * `controlled_phase_phase_relation` - The relation to use for the PhaseShiftedControlledPhase gate.
@@ -173,6 +178,7 @@ impl TweezerDevice {
     ///
     /// * `TweezerDevice` - The new TweezerDevice instance.
     pub fn new(
+        seed: Option<usize>,
         controlled_z_phase_relation: Option<String>,
         controlled_phase_phase_relation: Option<String>,
     ) -> Self {
@@ -190,6 +196,8 @@ impl TweezerDevice {
             controlled_z_phase_relation,
             controlled_phase_phase_relation,
             default_layout: None,
+            seed: seed.unwrap_or_default(),
+            qrydbackend: "qryd_tweezer_device".to_string(),
         }
     }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -639,9 +639,7 @@ impl TweezerDevice {
         Ok(())
     }
 
-    /// Set the name of the default layout to use.
-    ///
-    /// Additionally, switch to the layout.
+    /// Set the name of the default layout to use and switch to it.
     ///
     /// # Arguments
     ///

--- a/roqoqo-qryd/tests/integration/api_backend.rs
+++ b/roqoqo-qryd/tests/integration/api_backend.rs
@@ -35,7 +35,7 @@ fn api_backend() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -168,7 +168,7 @@ fn api_backend() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -260,7 +260,7 @@ fn api_backend_failing() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
         // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
@@ -291,7 +291,7 @@ fn api_backend_with_constant_circuit() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
         // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
@@ -411,7 +411,7 @@ fn api_triangular() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
         assert!(!job_loc.is_empty());
@@ -493,7 +493,7 @@ fn api_triangular() {
             )
             .create();
 
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
         assert!(!job_loc.is_empty());
@@ -547,7 +547,7 @@ fn evaluating_backend() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, Some(20), None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, Some(20), None, None).unwrap();
 
         let program_result = program.run(api_backend_new, &[]).unwrap().unwrap();
         assert_eq!(program_result.get("test"), Some(&-3.0));
@@ -616,7 +616,8 @@ fn evaluating_backend() {
             )
             .create();
 
-        let api_backend_new = APIBackend::new(qryd_device, None, Some(20), Some(port)).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, Some(20), Some(port), None).unwrap();
 
         let program_result = program.run(api_backend_new.clone(), &[]).unwrap().unwrap();
 
@@ -737,7 +738,7 @@ fn api_delete() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
 
         let job_loc = api_backend_new
             .post_job(
@@ -769,7 +770,7 @@ fn api_delete() {
             .mock("DELETE", mockito::Matcher::Any)
             .with_status(200)
             .create();
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
 
@@ -788,7 +789,7 @@ fn api_backend_errorcase_const() {
     let device = QrydEmuSquareDevice::new(Some(2), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -800,7 +801,7 @@ fn api_backend_errorcase_const() {
             .chars()
             .rev()
             .collect::<String>();
-        APIBackend::new(qryd_device, None, None, Some(port)).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
     };
     // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
     let qubit_mapping: HashMap<usize, usize> = (0..number_qubits).map(|x| (x, x)).collect();
@@ -830,7 +831,7 @@ fn api_backend_errorcase3() {
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
 
     if env::var("QRYD_API_TOKEN").is_err() {
-        let api_backend_err = APIBackend::new(qryd_device.clone(), None, None, None);
+        let api_backend_err = APIBackend::new(qryd_device.clone(), None, None, None, None);
         assert!(api_backend_err.is_err());
         assert_eq!(
             api_backend_err.unwrap_err(),
@@ -839,8 +840,14 @@ fn api_backend_errorcase3() {
             }
         );
     }
-    let api_backend_new =
-        APIBackend::new(qryd_device, Some("DummyString".to_string()), None, None).unwrap();
+    let api_backend_new = APIBackend::new(
+        qryd_device,
+        Some("DummyString".to_string()),
+        None,
+        None,
+        None,
+    )
+    .unwrap();
 
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
@@ -877,7 +884,7 @@ fn api_backend_errorcase4() {
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
 
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -889,7 +896,7 @@ fn api_backend_errorcase4() {
             .chars()
             .rev()
             .collect::<String>();
-        APIBackend::new(qryd_device, None, None, Some(port)).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
     };
     let job_loc: String = "DummyString".to_string();
     let job_status = api_backend_new.get_job_status(job_loc.clone());
@@ -908,7 +915,7 @@ fn api_backend_errorcase5() {
     let device = QrydEmuSquareDevice::new(Some(2), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -921,7 +928,7 @@ fn api_backend_errorcase5() {
             .rev()
             .collect::<String>();
 
-        APIBackend::new(qryd_device, None, None, Some(port)).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
     };
     let measurement = ClassicalRegister {
         constant_circuit: None,
@@ -1001,7 +1008,7 @@ fn api_backend_errorcase6() {
         .create();
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
@@ -1050,7 +1057,7 @@ fn api_backend_errorcase7() {
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let api_backend_new =
-        APIBackend::new(qryd_device, None, None, Some("12345".to_string())).unwrap();
+        APIBackend::new(qryd_device, None, None, Some("12345".to_string()), None).unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
@@ -1134,7 +1141,7 @@ fn api_backend_errorcase8() {
 
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port)).unwrap();
+    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -43,10 +43,10 @@ fn test_new_triangular() {
 fn test_new_tweezer() {
     let device = TweezerDevice::new(Some(1), None, None);
     let apidevice = QRydAPIDevice::from(&device);
-    assert_eq!(device.seed, 1);
-    assert_eq!(device.seed, apidevice.seed());
-    assert_eq!(device.qrydbackend, "qryd_tweezer_device");
-    assert_eq!(device.qrydbackend, apidevice.qrydbackend());
+    assert_eq!(device.seed(), 1);
+    assert_eq!(device.seed(), apidevice.seed());
+    assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
+    assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
 
 // Test the functions from device trait of the square device emulator

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -12,7 +12,7 @@
 
 use roqoqo::devices::Device;
 use roqoqo_qryd::api_devices::{QRydAPIDevice, QrydEmuSquareDevice, QrydEmuTriangularDevice};
-use roqoqo_qryd::phi_theta_relation;
+use roqoqo_qryd::{phi_theta_relation, TweezerDevice};
 
 use ndarray::Array2;
 
@@ -23,8 +23,6 @@ fn test_new_square() {
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), 0);
     assert_eq!(device.seed(), apidevice.seed());
-    // assert_eq!(device.pcz_theta(), PI);
-    // assert_eq!(device.pcz_theta(), apidevice.pcz_theta());
     assert_eq!(device.qrydbackend(), "qryd_emu_cloudcomp_square");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
@@ -36,10 +34,19 @@ fn test_new_triangular() {
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), 1);
     assert_eq!(device.seed(), apidevice.seed());
-    // assert_eq!(device.pcz_theta(), 0.0);
-    // assert_eq!(device.pcz_theta(), apidevice.pcz_theta());
     assert_eq!(device.qrydbackend(), "qryd_emu_cloudcomp_triangle");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
+}
+
+// Test the new function of the tweezer device
+#[test]
+fn test_new_tweezer() {
+    let device = TweezerDevice::new(Some(1), None, None);
+    let apidevice = QRydAPIDevice::from(&device);
+    assert_eq!(device.seed, 1);
+    assert_eq!(device.seed, apidevice.seed());
+    assert_eq!(device.qrydbackend, "qryd_tweezer_device");
+    assert_eq!(device.qrydbackend, apidevice.qrydbackend());
 }
 
 // Test the functions from device trait of the square device emulator
@@ -79,6 +86,30 @@ fn test_numberqubits_triangular() {
 #[test]
 fn test_decoherencerates_triangular() {
     let device = QrydEmuTriangularDevice::new(None, None, None, None, None);
+    let apidevice = QRydAPIDevice::from(&device);
+    assert_eq!(
+        device.qubit_decoherence_rates(&0),
+        Some(Array2::zeros((3, 3).to_owned()))
+    );
+    assert_eq!(
+        apidevice.qubit_decoherence_rates(&0),
+        device.qubit_decoherence_rates(&0)
+    );
+}
+
+// Test the functions from device trait of the tweezer device
+#[test]
+fn test_numberqubits_tweezer() {
+    let device = TweezerDevice::new(None, None, None);
+    let apidevice = QRydAPIDevice::from(&device);
+    assert_eq!(device.number_qubits(), 0);
+    assert_eq!(apidevice.number_qubits(), device.number_qubits());
+}
+
+// Test the functions from device trait of the tweezer device
+#[test]
+fn test_decoherencerates_tweezer() {
+    let device = TweezerDevice::new(None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(
         device.qubit_decoherence_rates(&0),
@@ -374,6 +405,57 @@ fn test_gatetimes_triangular() {
     );
 }
 
+// Test the functions from device trait of the tweezer device
+#[test]
+fn test_gatetimes_tweezer() {
+    let mut device = TweezerDevice::new(None, None, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 0, 0.34, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 1, 0.34, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 2, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 0, 1, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 1, 2, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 2, 0, 0.34, None);
+    device.set_tweezer_three_qubit_gate_time("Toffoli", 0, 1, 2, 0.34, None);
+    device.set_tweezer_multi_qubit_gate_time("MultiQubitZZ", &[0, 1, 2], 0.23, None);
+    device.add_qubit_tweezer_mapping(0, 0).unwrap();
+    device.add_qubit_tweezer_mapping(1, 1).unwrap();
+    device.add_qubit_tweezer_mapping(2, 2).unwrap();
+    let apidevice = QRydAPIDevice::from(&device);
+
+    assert_eq!(
+        device.single_qubit_gate_time("PhaseShiftState1", &0),
+        apidevice.single_qubit_gate_time("PhaseShiftState1", &0)
+    );
+    assert_eq!(
+        device.single_qubit_gate_time("PhaseShiftState1", &1),
+        apidevice.single_qubit_gate_time("PhaseShiftState1", &1)
+    );
+    assert_eq!(
+        device.single_qubit_gate_time("PhaseShiftState1", &2),
+        apidevice.single_qubit_gate_time("PhaseShiftState1", &2)
+    );
+    assert_eq!(
+        device.two_qubit_gate_time("PhaseShiftedControlledPhase", &0, &1),
+        apidevice.two_qubit_gate_time("PhaseShiftedControlledPhase", &0, &1)
+    );
+    assert_eq!(
+        device.two_qubit_gate_time("PhaseShiftedControlledPhase", &1, &2),
+        apidevice.two_qubit_gate_time("PhaseShiftedControlledPhase", &1, &2)
+    );
+    assert_eq!(
+        device.two_qubit_gate_time("PhaseShiftedControlledPhase", &2, &0),
+        apidevice.two_qubit_gate_time("PhaseShiftedControlledPhase", &2, &0)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("Toffoli", &0, &1, &2),
+        apidevice.three_qubit_gate_time("Toffoli", &0, &1, &2)
+    );
+    assert_eq!(
+        device.multi_qubit_gate_time("MultiQubitZZ", &[0, 1, 2]),
+        apidevice.multi_qubit_gate_time("MultiQubitZZ", &[0, 1, 2])
+    );
+}
+
 // Test gatetime gate category
 #[test]
 fn test_gatetime_type() {
@@ -443,6 +525,18 @@ fn test_changedevice_square() {
 #[test]
 fn test_changedevice_triangular() {
     let mut device = QrydEmuTriangularDevice::new(None, None, None, None, None);
+    let mut apidevice = QRydAPIDevice::from(&device);
+    assert!(device.change_device("", &[]).is_err());
+    assert_eq!(
+        apidevice.change_device("", &[]),
+        device.change_device("", &[])
+    );
+}
+
+// Test the functions from device trait of the tweezer device
+#[test]
+fn test_changedevice_tweezer() {
+    let mut device = TweezerDevice::new(None, None, None);
     let mut apidevice = QRydAPIDevice::from(&device);
     assert!(device.change_device("", &[]).is_err());
     assert_eq!(
@@ -591,6 +685,26 @@ fn test_twoqubitedges_triangular() {
     assert_eq!(apidevice.two_qubit_edges(), device.two_qubit_edges());
 }
 
+#[test]
+fn test_twoqubitedges_tweezer() {
+    let mut device = TweezerDevice::new(None, None, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 0, 1, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 1, 2, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 2, 0, 0.34, None);
+    device.add_qubit_tweezer_mapping(0, 0).unwrap();
+    device.add_qubit_tweezer_mapping(1, 1).unwrap();
+    device.add_qubit_tweezer_mapping(2, 2).unwrap();
+    let apidevice = QRydAPIDevice::from(&device);
+    let two_qubit_edges: Vec<(usize, usize)> = vec![(0, 1), (1, 2), (2, 0)];
+    assert!(two_qubit_edges
+        .iter()
+        .all(|el| device.two_qubit_edges().contains(el)));
+    assert!(apidevice
+        .two_qubit_edges()
+        .iter()
+        .all(|el| device.two_qubit_edges().contains(el)));
+}
+
 // Test to_generic_device() for square device
 #[test]
 fn test_to_generic_device_square() {
@@ -671,13 +785,68 @@ fn test_to_generic_device_triangular() {
     }
 }
 
+// Test to_generic_device() for tweezer device
+#[test]
+fn test_to_generic_device_tweezer() {
+    let mut device = TweezerDevice::new(None, None, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 0, 0.34, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 1, 0.34, None);
+    device.set_tweezer_single_qubit_gate_time("PhaseShiftState1", 2, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 0, 1, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 1, 2, 0.34, None);
+    device.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 2, 0, 0.34, None);
+    device.add_qubit_tweezer_mapping(0, 0).unwrap();
+    device.add_qubit_tweezer_mapping(1, 1).unwrap();
+    device.add_qubit_tweezer_mapping(2, 2).unwrap();
+    let apidevice = QRydAPIDevice::from(&device);
+    let genericdevice = apidevice.to_generic_device();
+
+    assert_eq!(apidevice.number_qubits(), genericdevice.number_qubits());
+    assert_eq!(device.number_qubits(), genericdevice.number_qubits());
+    for qubit in 0..genericdevice.number_qubits() {
+        assert_eq!(
+            genericdevice
+                .single_qubit_gate_time("PhaseShiftState1", &qubit)
+                .unwrap(),
+            apidevice
+                .single_qubit_gate_time("PhaseShiftState1", &qubit)
+                .unwrap()
+        );
+    }
+    for qubit in 0..genericdevice.number_qubits() {
+        assert_eq!(
+            genericdevice.qubit_decoherence_rates(&qubit),
+            apidevice.qubit_decoherence_rates(&qubit)
+        );
+    }
+    for row in 0..genericdevice.number_qubits() {
+        for column in row + 1..genericdevice.number_qubits() {
+            if genericdevice
+                .two_qubit_gate_time("PhaseShiftedControlledPhase", &row, &column)
+                .is_some()
+            {
+                assert_eq!(
+                    genericdevice.two_qubit_gate_time("PhaseShiftedControlledPhase", &row, &column),
+                    apidevice.two_qubit_gate_time("PhaseShiftedControlledPhase", &row, &column)
+                )
+            }
+        }
+    }
+}
+
 #[test]
 fn test_phi_theta_relation() {
     let triangular = QrydEmuTriangularDevice::new(Some(0), None, None, None, None);
     let square = QrydEmuSquareDevice::new(Some(0), None, None);
+    let mut tweezer = TweezerDevice::new(Some(0), None, None);
+    tweezer.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledZ", 0, 1, 0.10, None);
+    tweezer.set_tweezer_two_qubit_gate_time("PhaseShiftedControlledPhase", 0, 1, 0.10, None);
+    tweezer.add_qubit_tweezer_mapping(0, 0).unwrap();
+    tweezer.add_qubit_tweezer_mapping(1, 1).unwrap();
     let triangular_f =
         QrydEmuTriangularDevice::new(Some(0), Some("2.13".to_string()), None, None, None);
     let square_f = QrydEmuSquareDevice::new(Some(0), Some("2.13".to_string()), None);
+    let tweezer_f = TweezerDevice::new(Some(0), Some("2.13".to_string()), None);
 
     assert_eq!(
         triangular.phase_shift_controlled_z().unwrap(),
@@ -688,6 +857,10 @@ fn test_phi_theta_relation() {
         phi_theta_relation("DefaultRelation", std::f64::consts::PI).unwrap()
     );
     assert_eq!(
+        tweezer.phase_shift_controlled_z().unwrap(),
+        phi_theta_relation("DefaultRelation", std::f64::consts::PI).unwrap()
+    );
+    assert_eq!(
         triangular.phase_shift_controlled_phase(1.2).unwrap(),
         phi_theta_relation("DefaultRelation", 1.2).unwrap()
     );
@@ -695,8 +868,13 @@ fn test_phi_theta_relation() {
         square.phase_shift_controlled_phase(1.2).unwrap(),
         phi_theta_relation("DefaultRelation", 1.2).unwrap()
     );
+    assert_eq!(
+        tweezer.phase_shift_controlled_phase(1.2).unwrap(),
+        phi_theta_relation("DefaultRelation", 1.2).unwrap()
+    );
     assert_eq!(triangular_f.phase_shift_controlled_z(), Some(2.13));
     assert_eq!(square_f.phase_shift_controlled_z(), Some(2.13));
+    assert_eq!(tweezer_f.phase_shift_controlled_z(), Some(2.13));
 
     assert!(triangular.gate_time_controlled_z(&0, &13, 1.4).is_none());
     assert!(triangular
@@ -706,12 +884,19 @@ fn test_phi_theta_relation() {
     assert!(square
         .gate_time_controlled_phase(&0, &13, 0.6, 1.4)
         .is_none());
+    assert!(tweezer.gate_time_controlled_z(&0, &9, 1.3).is_none());
+    assert!(tweezer
+        .gate_time_controlled_phase(&0, &9, 1.3, 1.4)
+        .is_none());
 
     assert!(triangular
         .gate_time_controlled_z(&0, &1, triangular.phase_shift_controlled_z().unwrap())
         .is_some());
     assert!(square
         .gate_time_controlled_z(&0, &1, square.phase_shift_controlled_z().unwrap())
+        .is_some());
+    assert!(tweezer
+        .gate_time_controlled_z(&0, &1, triangular.phase_shift_controlled_z().unwrap())
         .is_some());
     assert!(triangular
         .gate_time_controlled_phase(
@@ -729,11 +914,22 @@ fn test_phi_theta_relation() {
             0.1
         )
         .is_some());
+    assert!(tweezer
+        .gate_time_controlled_phase(
+            &0,
+            &1,
+            square.phase_shift_controlled_phase(0.1).unwrap(),
+            0.1
+        )
+        .is_some());
 
     assert!(triangular
         .gate_time_controlled_z(&0, &1, triangular.phase_shift_controlled_z().unwrap() + 0.2)
         .is_none());
     assert!(square
+        .gate_time_controlled_z(&0, &1, square.phase_shift_controlled_z().unwrap() + 0.2)
+        .is_none());
+    assert!(tweezer
         .gate_time_controlled_z(&0, &1, square.phase_shift_controlled_z().unwrap() + 0.2)
         .is_none());
     assert!(triangular
@@ -745,6 +941,14 @@ fn test_phi_theta_relation() {
         )
         .is_none());
     assert!(square
+        .gate_time_controlled_phase(
+            &0,
+            &1,
+            square.phase_shift_controlled_phase(0.1).unwrap() + 0.2,
+            0.1
+        )
+        .is_none());
+    assert!(tweezer
         .gate_time_controlled_phase(
             &0,
             &1,

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -695,4 +695,5 @@ fn test_default_layout() {
 
     assert!(device.set_default_layout("triangle").is_ok());
     assert_eq!(device.default_layout, Some("triangle".to_string()));
+    assert_eq!(device.current_layout, "triangle".to_string());
 }

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -31,8 +31,8 @@ fn test_new() {
     assert!(device.qubit_to_tweezer.is_none());
     assert_eq!(device.layout_register.len(), 1);
     assert!(device.layout_register.get("default").is_some());
-    assert_eq!(device.seed, 2);
-    assert_eq!(device.qrydbackend, "qryd_tweezer_device");
+    assert_eq!(device.seed(), 2);
+    assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
 }
 
 // Test TweezerDevice add_layout(), switch_layout() methods

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -25,18 +25,20 @@ use mockito::Server;
 /// Test TweezerDevice new()
 #[test]
 fn test_new() {
-    let device = TweezerDevice::new(None, None);
+    let device = TweezerDevice::new(Some(2), None, None);
 
     assert_eq!(device.current_layout, "default");
     assert!(device.qubit_to_tweezer.is_none());
     assert_eq!(device.layout_register.len(), 1);
     assert!(device.layout_register.get("default").is_some());
+    assert_eq!(device.seed, 2);
+    assert_eq!(device.qrydbackend, "qryd_tweezer_device");
 }
 
 // Test TweezerDevice add_layout(), switch_layout() methods
 #[test]
 fn test_layouts() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert!(device.available_layouts().contains(&"default"));
 
@@ -177,7 +179,7 @@ fn test_layouts() {
 // Test TweezerDevice add_qubit_tweezer_mapping(), get_tweezer_from_qubit() methods
 #[test]
 fn test_qubit_tweezer_mapping() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert!(device.add_qubit_tweezer_mapping(0, 0).is_err());
     assert!(device.get_tweezer_from_qubit(&0).is_err());
@@ -200,7 +202,7 @@ fn test_qubit_tweezer_mapping() {
 /// Test TweezerDevice set_allowed_tweezer_shifts_from_rows() method
 #[test]
 fn test_allowed_tweezer_shifts_from_rows() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("triangle").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.0, Some("triangle".to_string()));
     device.set_tweezer_single_qubit_gate_time("PauliX", 1, 0.0, Some("triangle".to_string()));
@@ -246,7 +248,7 @@ fn test_allowed_tweezer_shifts_from_rows() {
 /// Test TweezerDevice set_allowed_tweezer_shifts() method
 #[test]
 fn test_allowed_tweezer_shifts_row() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("OtherLayout").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.0, Some("OtherLayout".to_string()));
     device.set_tweezer_single_qubit_gate_time("PauliX", 1, 0.0, Some("OtherLayout".to_string()));
@@ -303,7 +305,7 @@ fn test_allowed_tweezer_shifts_row() {
 /// Test TweezerDevice deactivate_qubit()
 #[test]
 fn test_deactivate_qubit() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert!(device.deactivate_qubit(0).is_err());
 
@@ -317,7 +319,7 @@ fn test_deactivate_qubit() {
 /// Test TweezerDevice ..._qubit_gate_time() methods
 #[test]
 fn test_qubit_times() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert!(device.single_qubit_gate_time("PauliX", &0).is_none());
 
@@ -359,7 +361,7 @@ fn test_qubit_times() {
 /// Test TweezerDevice number_qubits() method
 #[test]
 fn test_number_qubits() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert_eq!(device.number_qubits(), 0);
 
@@ -377,7 +379,7 @@ fn test_number_qubits() {
 /// Test TweezerDevice to_generic_device() method method
 #[test]
 fn test_to_generic_device() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, None);
     device.set_tweezer_single_qubit_gate_time("PauliY", 1, 0.23, None);
     device.set_tweezer_two_qubit_gate_time("CNOT", 2, 3, 0.34, None);
@@ -438,7 +440,7 @@ fn test_to_generic_device() {
 /// Test TweezerDevice change_device() method
 #[test]
 fn test_change_device() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("Test").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, Some("Test".to_string()));
     device.set_tweezer_single_qubit_gate_time("PauliY", 1, 0.23, Some("Test".to_string()));
@@ -484,7 +486,7 @@ fn test_change_device() {
 /// Test TweezerDevice change_device() method with PragmaShiftQubitsTweezers
 #[test]
 fn test_change_device_shift() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("triangle").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, Some("triangle".to_string()));
     device.set_tweezer_single_qubit_gate_time("PauliY", 1, 0.23, Some("triangle".to_string()));
@@ -565,7 +567,7 @@ fn test_change_device_shift() {
 #[test]
 #[cfg(feature = "web-api")]
 fn test_from_api() {
-    let mut returned_device_default = TweezerDevice::new(None, None);
+    let mut returned_device_default = TweezerDevice::new(None, None, None);
     returned_device_default.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, None);
     let mut server = Server::new();
     let port = server
@@ -614,8 +616,8 @@ fn test_from_api() {
 /// Test TweezerDevice phase_shift_controlled_...() and gate_time_controlled_...()  methods
 #[test]
 fn test_phi_theta_relation() {
-    let mut device = TweezerDevice::new(None, None);
-    let device_f = TweezerDevice::new(Some(2.13.to_string()), Some(2.15.to_string()));
+    let mut device = TweezerDevice::new(None, None, None);
+    let device_f = TweezerDevice::new(None, Some(2.13.to_string()), Some(2.15.to_string()));
 
     assert_eq!(
         device.phase_shift_controlled_z().unwrap(),
@@ -669,7 +671,7 @@ fn test_phi_theta_relation() {
 // Test TweezerDevice two_tweezer_edges() method
 #[test]
 fn test_two_tweezer_edges() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
 
     assert_eq!(device.two_tweezer_edges().len(), 0);
 
@@ -687,7 +689,7 @@ fn test_two_tweezer_edges() {
 
 #[test]
 fn test_default_layout() {
-    let mut device = TweezerDevice::new(None, None);
+    let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("triangle").unwrap();
     device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, Some("triangle".to_string()));
 


### PR DESCRIPTION
* Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set
* Modified `TweezerDevice.` and `TweezerMutableDevice.to_json()` such that it returns an error in case no QRyd-valid gates are executable
* Added `TweezerDevice.from_mutable()` static method
* Added `dev` parameter in `APIBackend` constructor
* Added `TweezerDevice` support for `APIBackend`