### PR TITLE
Additional Fixes

### DIFF
--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -26,5 +26,5 @@ jobs:
       # Run tests also on macos runners
       macos: true
       py_interface_folder: "qoqo-qryd"
-      has_python_tests: true
+      has_python_tests: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Tracks qoqo-qryd changes after 0.5
 # 0.11.4
 
 * Added `seed` parameter to `TweezerDevice.from_api()`
+* Fixed `TweezerDevice` support for `APIBackend`
 
 # 0.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.11.4
+
+* Added `seed` parameter to `TweezerDevice.from_api()`
+
 # 0.11.3
 
 * Modified `TweezerDevice.from_json()` and `TweezerMutableDevice.set_default_layout()` to automatically switch the layout of the device if a default one was set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Tracks qoqo-qryd changes after 0.5
 
 * Added `seed` parameter to `TweezerDevice.from_api()`
 * Fixed `TweezerDevice` support for `APIBackend`
+* Modified `TweezerDevice` seed parameter to default to None, instead of 0
 
 # 0.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.11.4
 
-* Added `seed` parameter to `TweezerDevice.from_api()`
+* Added `api_version`, `seed` parameters to `TweezerDevice.from_api()`
 * Fixed `TweezerDevice` support for `APIBackend`
 * Modified `TweezerDevice` seed parameter to default to None, instead of 0
 * Added `api_version` parameter to `APIBackend`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.11.4
 
-* Added `api_version`, `seed` parameters to `TweezerDevice.from_api()`
+* Added `api_version`, `seed`, `dev` parameters to `TweezerDevice.from_api()`
 * Fixed `TweezerDevice` support for `APIBackend`
 * Modified `TweezerDevice` seed parameter to default to None, instead of 0
 * Added `api_version` parameter to `APIBackend`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Tracks qoqo-qryd changes after 0.5
 * Added `seed` parameter to `TweezerDevice.from_api()`
 * Fixed `TweezerDevice` support for `APIBackend`
 * Modified `TweezerDevice` seed parameter to default to None, instead of 0
+* Added `api_version` parameter to `APIBackend`
 
 # 0.11.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "qoqo"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6348fdb820ba16927418cdf5368c1a5d52bd11fdfb6393f0f9e998d3ee5d8065"
+checksum = "d1dbcc69ae965d0c19f9ce0d4290db77689e3a22462fe0fbcf93fc85939a969e"
 dependencies = [
  "bincode",
  "ndarray",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "qoqo-macros"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31f71e03276b5a5381d74ee3d77f23e528d1e9ec40b2cecbb88665bd5dbc62f"
+checksum = "e0361ef299a5691f0ae9ed9bf6eccaa468d61d98635e6aa60730dc46585d2cc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302b7db9cf1e9e264ec07e09fe5bc22ffd142f9dac0f73335d7197ddc778255f"
+checksum = "8a707439111ba01be3495fe64c9c2d92b8033c08781b0b91162ca43383c65c0e"
 dependencies = [
  "bincode",
  "nalgebra",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-derive"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d9c82a1720f928bb19df60c57864d56efabcb9aec416bc00f2b22e9267ea55"
+checksum = "0db8bafb647b00998af3cd0e9073a82a60a1f87cfc925b56b3cc94c03cf0cb25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-test"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977c118d6958be1cde7a90b40af0f633704a70df0b01c9cd5551d9031013c21e"
+checksum = "66d6c4a2f14b78a963f382812de4ad3a2065ad8c9954260eb0c0af0a132a6f8d"
 dependencies = [
  "nalgebra",
  "ndarray",
@@ -1309,18 +1309,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -258,7 +258,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -497,15 +497,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "lock_api"
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -897,7 +897,7 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py",
- "syn 2.0.37",
+ "syn 2.0.38",
  "thiserror",
 ]
 
@@ -909,12 +909,12 @@ checksum = "f31f71e03276b5a5381d74ee3d77f23e528d1e9ec40b2cecbb88665bd5dbc62f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bincode",
  "mockito",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "qoqo_calculator"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ecdd0eebe8a6d299cc47d3430b32fc874b2868e9508b0cc5939af5eedf926d"
+checksum = "5e6515bd58ad1b17af70c5dcf8f3e6bc34c3b42b6b44f1dc2a5c3ce2d00e4f21"
 dependencies = [
  "num-complex",
  "schemars",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "qoqo_calculator_pyo3"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e6c552b739553c42844f492b8c3a621f5edd76008119d360d7b8bd85dd3c94"
+checksum = "a1273ea1dd0b462f7a4ae9b98908cf9ad1d99c803f10483dd6af8b49f7944403"
 dependencies = [
  "num-complex",
  "pyo3",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
 name = "reqwest"
@@ -1140,7 +1140,7 @@ dependencies = [
  "roqoqo-derive",
  "serde",
  "struqture",
- "syn 2.0.37",
+ "syn 2.0.38",
  "thiserror",
 ]
 
@@ -1152,12 +1152,12 @@ checksum = "29d9c82a1720f928bb19df60c57864d56efabcb9aec416bc00f2b22e9267ea55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bincode",
  "bitvec",
@@ -1206,7 +1206,7 @@ dependencies = [
  "quote",
  "rand",
  "roqoqo",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1324,7 +1324,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "slab"
@@ -1476,7 +1476,7 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py-macros",
- "syn 2.0.37",
+ "syn 2.0.38",
  "thiserror",
 ]
 
@@ -1489,7 +1489,7 @@ dependencies = [
  "num-complex",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1566,7 +1566,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "test-case-core",
 ]
 
@@ -1599,7 +1599,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1620,9 +1620,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1645,7 +1645,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1796,7 +1796,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -1830,7 +1830,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
   'numpy',
   'qoqo>=1.6',

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -20119,7 +20119,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.11.3
+qoqo-qryd 0.11.4
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -23862,7 +23862,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.11.3
+roqoqo-qryd 0.11.4
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -495,7 +495,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-aho-corasick 1.1.1
+aho-corasick 1.1.2
 https://github.com/BurntSushi/aho-corasick
 by Andrew Gallant <jamslam@gmail.com>
 Fast multiple substring searching.
@@ -11690,7 +11690,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libc 0.2.148
+libc 0.2.149
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -11907,7 +11907,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libm 0.2.7
+libm 0.2.8
 https://github.com/rust-lang/libm
 by Jorge Aparicio <jorge@japaric.io>
 libm in pure Rust
@@ -14710,7 +14710,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-num-traits 0.2.16
+num-traits 0.2.17
 https://github.com/rust-num/num-traits
 by The Rust Project Developers
 Numeric traits for generic mathematics
@@ -18054,7 +18054,7 @@ SOFTWARE.
 
 
 ====================================================
-proc-macro2 1.0.67
+proc-macro2 1.0.69
 https://github.com/dtolnay/proc-macro2
 by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.
@@ -19696,7 +19696,7 @@ LICENSE:
 
 
 ====================================================
-qoqo 1.7.0
+qoqo 1.7.1
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Quantum computing circuit toolkit. Python interface of roqoqo
@@ -19908,7 +19908,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-macros 1.7.0
+qoqo-macros 1.7.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the qoqo crate
 License: Apache-2.0
@@ -20331,7 +20331,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_calculator 1.1.2
+qoqo_calculator 1.1.3
 https://github.com/HQSquantumsimulations/qoqo_calculator
 by HQS Quantum Simulations <info@quantumsimulations.de>
 qoqo-calculator is the calculator backend of the qoqo quantum computing toolkit by HQS Quantum Simulations
@@ -20543,7 +20543,7 @@ LICENSE:
 
 
 ====================================================
-qoqo_calculator_pyo3 1.1.2
+qoqo_calculator_pyo3 1.1.3
 https://github.com/HQSquantumsimulations/qoqo_calculator_pyo3
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface to qoqo calculator, the calculator backend of the qoqo quantum computing toolkit by HQS Quantum Simulations
@@ -22472,7 +22472,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex 1.9.6
+regex 1.10.0
 https://github.com/rust-lang/regex
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 An implementation of regular expressions for Rust. This implementation uses
@@ -22715,7 +22715,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-automata 0.3.9
+regex-automata 0.4.1
 https://github.com/rust-lang/regex/tree/master/regex-automata
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 Automata construction and matching using regular expressions.
@@ -22956,7 +22956,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-syntax 0.7.5
+regex-syntax 0.8.1
 https://github.com/rust-lang/regex/tree/master/regex-syntax
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 A regular expression parser.
@@ -23439,7 +23439,7 @@ by Brian Smith <brian@briansmith.org>
 Safe, fast, small crypto using Rust.
 
 ====================================================
-roqoqo 1.7.0
+roqoqo 1.7.1
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Rust Quantum Computing Toolkit by HQS
@@ -23651,7 +23651,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-derive 1.7.0
+roqoqo-derive 1.7.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for the roqoqo crate
 License: Apache-2.0
@@ -24286,7 +24286,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-test 1.7.0
+roqoqo-test 1.7.1
 https://github.com/HQSquantumsimulations/qoqo
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Testing helper functions for roqoqo toolkit
@@ -26441,7 +26441,7 @@ THIS SOFTWARE.
 
 
 ====================================================
-serde 1.0.188
+serde 1.0.189
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -26655,7 +26655,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.188
+serde_derive 1.0.189
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -28205,7 +28205,7 @@ LICENSE:
 
 
 ====================================================
-similar 2.2.1
+similar 2.3.0
 https://github.com/mitsuhiko/similar
 by Armin Ronacher <armin.ronacher@active-4.com>, Pierre-Étienne Meunier <pe@pijul.org>, Brandon Williams <bwilliams.eng@gmail.com>
 A diff library for Rust
@@ -29881,7 +29881,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-syn 2.0.37
+syn 2.0.38
 https://github.com/dtolnay/syn
 by David Tolnay <dtolnay@gmail.com>
 Parser for Rust source code
@@ -31395,7 +31395,7 @@ freely, subject to the following restrictions:
 
 
 ====================================================
-tokio 1.32.0
+tokio 1.33.0
 https://tokio.rs
 by Tokio Contributors <team@tokio.rs>
 An event-driven, non-blocking I/O platform for writing asynchronous I/O

--- a/qoqo-qryd/src/api_backend.rs
+++ b/qoqo-qryd/src/api_backend.rs
@@ -461,6 +461,7 @@ impl APIBackendWrapper {
     /// Args:
     ///     dev (bool): The boolean to set the dev option to.
     ///
+    #[pyo3(text_signature = "($self, dev, /)")]
     pub fn set_dev(&mut self, dev: bool) {
         self.internal.set_dev(dev);
     }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -111,12 +111,13 @@ impl TweezerDeviceWrapper {
     /// This requires a valid QRYD_API_TOKEN. Visit `https://thequantumlaend.de/get-access/` to get one.
     ///
     /// Args
-    ///     device_name (Optional[str]): The name of the device to instantiate. Defaults to "Default".
+    ///     device_name (Optional[str]): The name of the device to instantiate. Defaults to "test_device".
     ///     access_token (Optional[str]): An access_token is required to access QRYD hardware and emulators.
     ///                         The access_token can either be given as an argument here
     ///                             or set via the environmental variable `$QRYD_API_TOKEN`.
     ///     mock_port (Optional[str]): Server port to be used for testing purposes.
     ///     seed (Optional[int]): Optionally overwrite seed value from downloaded device instance.
+    ///     api_version (Optional[str]): The version of the QRYD API to use. Defaults to "v1_0".
     ///
     /// Returns
     ///     TweezerDevice: The new TweezerDevice instance with populated tweezer data.
@@ -125,15 +126,17 @@ impl TweezerDeviceWrapper {
     ///     RoqoqoBackendError
     #[staticmethod]
     #[cfg(feature = "web-api")]
-    #[pyo3(text_signature = "(device_name, access_token, seed, /)")]
+    #[pyo3(text_signature = "(device_name, access_token, mock_port, seed, api_version, /)")]
     pub fn from_api(
         device_name: Option<String>,
         access_token: Option<String>,
         mock_port: Option<String>,
         seed: Option<usize>,
+        api_version: Option<String>,
     ) -> PyResult<Self> {
-        let internal = TweezerDevice::from_api(device_name, access_token, mock_port, seed)
-            .map_err(|err| PyValueError::new_err(format!("{:}", err)))?;
+        let internal =
+            TweezerDevice::from_api(device_name, access_token, mock_port, seed, api_version)
+                .map_err(|err| PyValueError::new_err(format!("{:}", err)))?;
         Ok(TweezerDeviceWrapper { internal })
     }
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -44,7 +44,7 @@ impl TweezerDeviceWrapper {
     /// Creates a new TweezerDevice instance.
     ///
     /// Args:
-    ///     seed (int): Seed, if not provided will be set to 0 per default (not recommended!)
+    ///     seed (int): Optional seed, for simulation purposes.
     ///     controlled_z_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledZ gate.
     ///     controlled_phase_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledPhase gate.
     ///
@@ -522,7 +522,7 @@ impl TweezerDeviceWrapper {
     }
 
     /// Returns the seed usized for the API.
-    pub fn seed(&self) -> usize {
+    pub fn seed(&self) -> Option<usize> {
         self.internal.seed()
     }
 
@@ -567,7 +567,7 @@ impl TweezerMutableDeviceWrapper {
     /// Creates a new TweezerMutableDevice instance.
     ///
     /// Args:
-    ///     seed (int): Seed, if not provided will be set to 0 per default (not recommended!)
+    ///     seed (int): Optional seed, for simulation purposes.
     ///     controlled_z_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledZ gate.
     ///     controlled_phase_phase_relation (Optional[Union[str, float]]): The relation to use for the PhaseShiftedControlledPhase gate.
     ///
@@ -1011,7 +1011,7 @@ impl TweezerMutableDeviceWrapper {
     }
 
     /// Returns the seed usized for the API.
-    pub fn seed(&self) -> usize {
+    pub fn seed(&self) -> Option<usize> {
         self.internal.seed()
     }
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -116,6 +116,7 @@ impl TweezerDeviceWrapper {
     ///                         The access_token can either be given as an argument here
     ///                             or set via the environmental variable `$QRYD_API_TOKEN`.
     ///     mock_port (Optional[str]): Server port to be used for testing purposes.
+    ///     seed (Optional[int]): Optionally overwrite seed value from downloaded device instance.
     ///
     /// Returns
     ///     TweezerDevice: The new TweezerDevice instance with populated tweezer data.
@@ -124,13 +125,14 @@ impl TweezerDeviceWrapper {
     ///     RoqoqoBackendError
     #[staticmethod]
     #[cfg(feature = "web-api")]
-    #[pyo3(text_signature = "(device_name, access_token, /)")]
+    #[pyo3(text_signature = "(device_name, access_token, seed, /)")]
     pub fn from_api(
         device_name: Option<String>,
         access_token: Option<String>,
         mock_port: Option<String>,
+        seed: Option<usize>,
     ) -> PyResult<Self> {
-        let internal = TweezerDevice::from_api(device_name, access_token, mock_port)
+        let internal = TweezerDevice::from_api(device_name, access_token, mock_port, seed)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))?;
         Ok(TweezerDeviceWrapper { internal })
     }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -117,6 +117,7 @@ impl TweezerDeviceWrapper {
     ///                             or set via the environmental variable `$QRYD_API_TOKEN`.
     ///     mock_port (Optional[str]): Server port to be used for testing purposes.
     ///     seed (Optional[int]): Optionally overwrite seed value from downloaded device instance.
+    ///     dev (Optional[bool]): The boolean to set the dev header to.
     ///     api_version (Optional[str]): The version of the QRYD API to use. Defaults to "v1_0".
     ///
     /// Returns
@@ -132,10 +133,11 @@ impl TweezerDeviceWrapper {
         access_token: Option<String>,
         mock_port: Option<String>,
         seed: Option<usize>,
+        dev: Option<bool>,
         api_version: Option<String>,
     ) -> PyResult<Self> {
         let internal =
-            TweezerDevice::from_api(device_name, access_token, mock_port, seed, api_version)
+            TweezerDevice::from_api(device_name, access_token, mock_port, seed, dev, api_version)
                 .map_err(|err| PyValueError::new_err(format!("{:}", err)))?;
         Ok(TweezerDeviceWrapper { internal })
     }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -21,7 +21,7 @@ use qoqo::{devices::GenericDeviceWrapper, QoqoBackendError};
 use qoqo_calculator_pyo3::convert_into_calculator_float;
 use roqoqo::devices::Device;
 
-use roqoqo_qryd::TweezerDevice;
+use roqoqo_qryd::{QRydAPIDevice, TweezerDevice};
 
 /// Tweezer Device
 ///
@@ -525,6 +525,25 @@ impl TweezerDeviceWrapper {
     pub fn seed(&self) -> usize {
         self.internal.seed()
     }
+
+    /// Return the bincode representation of the Enum variant of the Device.
+    ///
+    /// Only used for internal interfacing.
+    ///
+    /// Returns:
+    ///     ByteArray: The serialized TweezerDevice (in [bincode] form).
+    ///
+    /// Raises:
+    ///     ValueError: Cannot serialize Device to bytes.
+    pub fn _enum_to_bincode(&self) -> PyResult<Py<PyByteArray>> {
+        let qryd_enum: QRydAPIDevice = (&self.internal).into();
+        let serialized = bincode::serialize(&qryd_enum)
+            .map_err(|_| PyValueError::new_err("Cannot serialize TweezerDevice to bytes"))?;
+        let b: Py<PyByteArray> = Python::with_gil(|py| -> Py<PyByteArray> {
+            PyByteArray::new(py, &serialized[..]).into()
+        });
+        Ok(b)
+    }
 }
 
 /// Tweezer Mutable Device
@@ -994,6 +1013,25 @@ impl TweezerMutableDeviceWrapper {
     /// Returns the seed usized for the API.
     pub fn seed(&self) -> usize {
         self.internal.seed()
+    }
+
+    /// Return the bincode representation of the Enum variant of the Device.
+    ///
+    /// Only used for internal interfacing.
+    ///
+    /// Returns:
+    ///     ByteArray: The serialized TweezerMutableDevice (in [bincode] form).
+    ///
+    /// Raises:
+    ///     ValueError: Cannot serialize Device to bytes.
+    pub fn _enum_to_bincode(&self) -> PyResult<Py<PyByteArray>> {
+        let qryd_enum: QRydAPIDevice = (&self.internal).into();
+        let serialized = bincode::serialize(&qryd_enum)
+            .map_err(|_| PyValueError::new_err("Cannot serialize TweezerMutableDevice to bytes"))?;
+        let b: Py<PyByteArray> = Python::with_gil(|py| -> Py<PyByteArray> {
+            PyByteArray::new(py, &serialized[..]).into()
+        });
+        Ok(b)
     }
 
     /// Set the time of a single-qubit gate for a tweezer in a given Layout.

--- a/qoqo-qryd/tests/integration/api_backend.rs
+++ b/qoqo-qryd/tests/integration/api_backend.rs
@@ -748,9 +748,17 @@ fn test_convert_into_backend() {
         let rust_dev: QrydEmuSquareDevice = QrydEmuSquareDevice::new(Some(11), None, None);
         let rust_api: QRydAPIDevice = QRydAPIDevice::from(rust_dev);
         let rust_backend: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-            APIBackend::new(rust_api, none_string.clone(), Some(30), none_string, None).unwrap()
+            APIBackend::new(
+                rust_api,
+                none_string.clone(),
+                Some(30),
+                none_string,
+                None,
+                None,
+            )
+            .unwrap()
         } else {
-            APIBackend::new(rust_api, none_string, Some(30), Some(port), None).unwrap()
+            APIBackend::new(rust_api, none_string, Some(30), Some(port), None, None).unwrap()
         };
 
         assert_eq!(converted, rust_backend);

--- a/qoqo-qryd/tests/integration/api_backend.rs
+++ b/qoqo-qryd/tests/integration/api_backend.rs
@@ -795,6 +795,16 @@ fn test_bincode_square() {
 fn test_dev() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
+        let server = Server::new();
+        let port = server
+            .url()
+            .chars()
+            .rev()
+            .take(5)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect::<String>();
         let device_type = py.get_type::<QrydEmuSquareDeviceWrapper>();
         let device: &PyCell<QrydEmuSquareDeviceWrapper> = device_type
             .call1((11,))
@@ -808,19 +818,16 @@ fn test_dev() {
                 device,
                 Option::<String>::None,
                 Option::<usize>::None,
-                Option::<String>::None,
-                true,
+                port,
+                false,
             ))
             .unwrap()
             .downcast::<PyCell<APIBackendWrapper>>()
             .unwrap();
 
+        assert!(backend.call_method1("set_dev", (true,)).is_ok());
+
         let internal = &backend.borrow().internal;
-
         assert!(internal.dev);
-
-        assert!(backend.call_method1("set_dev", (false,)).is_ok());
-
-        assert!(!internal.dev);
     });
 }

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -821,15 +821,17 @@ fn test_two_qubit_edges() {
 fn test_from_api() {
     let mut sent_device = TweezerDevice::new(None, None, None);
     sent_device.add_layout("triangle").unwrap();
-    sent_device.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, Some("triangle".to_string()));
+    sent_device.set_tweezer_single_qubit_gate_time(
+        "PhaseShiftState1",
+        0,
+        0.23,
+        Some("triangle".to_string()),
+    );
     sent_device.set_default_layout("triangle").unwrap();
-    // let sent_device_wrapper = TweezerDeviceWrapper {
-    //     internal: sent_device.clone(),
-    // };
     let mut received_device = TweezerDevice::new(None, None, None);
     received_device.add_layout("triangle").unwrap();
     received_device.set_tweezer_single_qubit_gate_time(
-        "PauliX",
+        "PhaseShiftState1",
         0,
         0.23,
         Some("triangle".to_string()),
@@ -867,7 +869,7 @@ fn test_from_api() {
         let device = device_type
             .call_method1(
                 "from_api",
-                (Option::<String>::None, Option::<String>::None, port),
+                (Option::<String>::None, Option::<String>::None, port, 42),
             )
             .unwrap();
 
@@ -880,6 +882,14 @@ fn test_from_api() {
                 .extract::<String>()
                 .unwrap(),
             "triangle"
+        );
+        assert_eq!(
+            device
+                .call_method0("seed")
+                .unwrap()
+                .extract::<usize>()
+                .unwrap(),
+            42
         );
 
         let returned_device_string = device

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -57,17 +57,37 @@ fn test_new() {
         assert_eq!(
             res.call_method0("seed")
                 .unwrap()
-                .extract::<usize>()
+                .extract::<Option<usize>>()
                 .unwrap(),
-            2
+            Some(2)
         );
         assert_eq!(
             res_mut
                 .call_method0("seed")
                 .unwrap()
-                .extract::<usize>()
+                .extract::<Option<usize>>()
                 .unwrap(),
-            2
+            Some(2)
+        );
+
+        let res_emp = device_type.call0().unwrap();
+        let res_mut_emp = device_type_mut.call0().unwrap();
+
+        assert_eq!(
+            res_emp
+                .call_method0("seed")
+                .unwrap()
+                .extract::<Option<usize>>()
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            res_mut_emp
+                .call_method0("seed")
+                .unwrap()
+                .extract::<Option<usize>>()
+                .unwrap(),
+            None
         );
     })
 }

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -395,7 +395,7 @@ impl APIBackend {
     ///
     pub fn post_job(&self, quantumprogram: QuantumProgram) -> Result<String, RoqoqoBackendError> {
         // Prepare data that need to be passed to the WebAPI client
-        let seed_param: usize = self.device.seed(); // seed.unwrap_or(0);
+        let seed_param: Option<usize> = self.device.seed(); // seed.unwrap_or(0);
         let mut transform_pragma_repeated_measurement: bool = false;
 
         match &quantumprogram {
@@ -506,7 +506,7 @@ impl APIBackend {
             program: filtered_qp,
             dev: self.dev,
             fusion_max_qubits: 4,
-            seed_simulator: Some(seed_param),
+            seed_simulator: seed_param,
             seed_compiler: None,
             use_extended_set: true,
             use_reverse_traversal: true,

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -14,7 +14,6 @@ use crate::api_devices::QRydAPIDevice;
 use bitvec::prelude::*;
 use num_complex::Complex64;
 use reqwest::blocking::Client;
-use reqwest::blocking::Response;
 use roqoqo::backends::RegisterResult;
 use roqoqo::measurements::ClassicalRegister;
 use roqoqo::operations::Define;
@@ -543,17 +542,29 @@ impl APIBackend {
         // Call WebAPI client
         // here: value for put() temporarily fixed.
         // needs to be derived dynamically based on the provided parameter 'qrydbackend'
-        let resp: Response;
-        if let Some(mock_port) = &self.mock_port {
-            resp = client
+        let resp = if let Some(mock_port) = &self.mock_port {
+            client
                 .post(format!("http://127.0.0.1:{}", mock_port))
                 .json(&data)
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
                     msg: format!("{:?}", e),
-                })?;
+                })?
+        } else if self.dev {
+            client
+                .post(format!(
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/jobs",
+                    self.api_version
+                ))
+                .header("X-API-KEY", self.access_token.clone())
+                .header("X-DEV", "?1")
+                .json(&data)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
         } else {
-            resp = client
+            client
                 .post(format!(
                     "https://api.qryddemo.itp3.uni-stuttgart.de/{}/jobs",
                     self.api_version
@@ -563,8 +574,8 @@ impl APIBackend {
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
                     msg: format!("{:?}", e),
-                })?;
-        }
+                })?
+        };
 
         let status_code = resp.status();
         if status_code != reqwest::StatusCode::CREATED {
@@ -637,14 +648,26 @@ impl APIBackend {
         let url_string: String = job_location + "/status";
 
         // Call WebAPI client
-        let resp = client
-            .get(url_string)
-            .header("X-API-KEY", self.access_token.clone())
-            // .json(&data)
-            .send()
-            .map_err(|e| RoqoqoBackendError::NetworkError {
-                msg: format!("{:?}", e),
-            })?;
+        let resp = if self.dev {
+            client
+                .get(url_string)
+                .header("X-API-KEY", self.access_token.clone())
+                .header("X-DEV", "?1")
+                // .json(&data)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        } else {
+            client
+                .get(url_string)
+                .header("X-API-KEY", self.access_token.clone())
+                // .json(&data)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        };
 
         let status_code = resp.status();
         if status_code != reqwest::StatusCode::OK {
@@ -710,14 +733,26 @@ impl APIBackend {
         let url_string: String = job_location + "/result";
 
         // Call WebAPI client
-        let resp = client
-            .get(url_string)
-            .header("X-API-KEY", self.access_token.clone())
-            // .json(&data)
-            .send()
-            .map_err(|e| RoqoqoBackendError::NetworkError {
-                msg: format!("{:?}", e),
-            })?;
+        let resp = if self.dev {
+            client
+                .get(url_string)
+                .header("X-API-KEY", self.access_token.clone())
+                .header("X-DEV", "?1")
+                // .json(&data)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        } else {
+            client
+                .get(url_string)
+                .header("X-API-KEY", self.access_token.clone())
+                // .json(&data)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        };
 
         let status_code = resp.status();
         if status_code != reqwest::StatusCode::OK {
@@ -775,13 +810,24 @@ impl APIBackend {
                 })?
         };
         // Call WebAPI client
-        let resp = client
-            .delete(job_location)
-            .header("X-API-KEY", self.access_token.clone())
-            .send()
-            .map_err(|e| RoqoqoBackendError::NetworkError {
-                msg: format!("{:?}", e),
-            })?;
+        let resp = if self.dev {
+            client
+                .delete(job_location)
+                .header("X-API-KEY", self.access_token.clone())
+                .header("X-DEV", "?1")
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        } else {
+            client
+                .delete(job_location)
+                .header("X-API-KEY", self.access_token.clone())
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        };
 
         let status_code = resp.status();
         if status_code != reqwest::StatusCode::OK {

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -59,6 +59,8 @@ pub struct APIBackend {
 /// Local struct representing the body of the request message
 #[derive(Debug, serde::Serialize)]
 struct QRydRunData {
+    /// Format of the quantum program: qoqo
+    format: String,
     /// The QRyd WebAPI Backend used to execute operations and circuits.
     /// At the moment limited to the QRyd emulators
     /// ('qryd_emu_localcomp_square', 'qryd_emu_localcomp_triangle',
@@ -508,6 +510,7 @@ impl APIBackend {
         //     downconvert_roqoqo_version(quantumprogram)?;
         // dbg!(&serde_json::to_string(&quantumprogram).unwrap());
         let data = QRydRunData {
+            format: "qoqo".to_string(),
             backend: self.device.qrydbackend(),
             program: filtered_qp,
             dev: self.dev,
@@ -551,7 +554,10 @@ impl APIBackend {
                 })?;
         } else {
             resp = client
-                .post(format!("https://api.qryddemo.itp3.uni-stuttgart.de/{}/jobs", self.api_version))
+                .post(format!(
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/jobs",
+                    self.api_version
+                ))
                 .header("X-API-KEY", self.access_token.clone())
                 .json(&data)
                 .send()
@@ -1004,6 +1010,7 @@ mod test {
         // let program: roqoqo_1_0::QuantumProgram = downconvert_roqoqo_version(program).unwrap();
 
         let test = QRydRunData {
+            format: "qoqo".to_string(),
             backend: "qryd_emu_cloudcomp_square".to_string(),
             program,
             dev: false,
@@ -1016,7 +1023,7 @@ mod test {
             extended_set_weight: 0.5,
             reverse_traversal_iterations: 2,
         };
-        assert_eq!(format!("{:?}", test), "QRydRunData { backend: \"qryd_emu_cloudcomp_square\", dev: false, fusion_max_qubits: 4, seed_simulator: None, seed_compiler: None, use_extended_set: true, use_reverse_traversal: true, reverse_traversal_iterations: 2, extended_set_size: 5, extended_set_weight: 0.5, program: ClassicalRegister { measurement: ClassicalRegister { constant_circuit: None, circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }] }, input_parameter_names: [\"test\"] } }");
+        assert_eq!(format!("{:?}", test), "QRydRunData { format: \"qoqo\", backend: \"qryd_emu_cloudcomp_square\", dev: false, fusion_max_qubits: 4, seed_simulator: None, seed_compiler: None, use_extended_set: true, use_reverse_traversal: true, reverse_traversal_iterations: 2, extended_set_size: 5, extended_set_weight: 0.5, program: ClassicalRegister { measurement: ClassicalRegister { constant_circuit: None, circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }] }, input_parameter_names: [\"test\"] } }");
     }
 
     /// Test Debug of QRydJobResult
@@ -1309,6 +1316,7 @@ mod test {
             input_parameter_names: vec![],
         };
         let data = QRydRunData {
+            format: "qoqo".to_string(),
             backend: device.qrydbackend(),
             program: output_program,
             dev: false,

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -52,6 +52,8 @@ pub struct APIBackend {
     mock_port: Option<String>,
     /// Is develop version. Defaults to `false`.
     pub dev: bool,
+    /// API version.
+    api_version: String,
 }
 
 /// Local struct representing the body of the request message
@@ -344,6 +346,7 @@ impl APIBackend {
     ///               been queried `timeout` times.
     /// * `mock_port` - Server port to be used for testing purposes.
     /// * `dev` - The boolean to set the dev option to.
+    /// * `api_version` - The version of the QRyd WebAPI to use. Defaults to "v3_0".
     ///
     pub fn new(
         device: QRydAPIDevice,
@@ -351,6 +354,7 @@ impl APIBackend {
         timeout: Option<usize>,
         mock_port: Option<String>,
         dev: Option<bool>,
+        api_version: Option<String>,
     ) -> Result<Self, RoqoqoBackendError> {
         if mock_port.is_some() {
             Ok(Self {
@@ -359,6 +363,7 @@ impl APIBackend {
                 timeout: timeout.unwrap_or(30),
                 mock_port,
                 dev: false,
+                api_version: api_version.unwrap_or("v3_0".to_string()),
             })
         } else {
             let access_token_internal: String = match access_token {
@@ -376,6 +381,7 @@ impl APIBackend {
                 timeout: timeout.unwrap_or(30),
                 mock_port,
                 dev: dev.unwrap_or(false),
+                api_version: api_version.unwrap_or("v3_0".to_string()),
             })
         }
     }
@@ -545,7 +551,7 @@ impl APIBackend {
                 })?;
         } else {
             resp = client
-                .post("https://api.qryddemo.itp3.uni-stuttgart.de/v3_0/jobs")
+                .post(format!("https://api.qryddemo.itp3.uni-stuttgart.de/{}/jobs", self.api_version))
                 .header("X-API-KEY", self.access_token.clone())
                 .json(&data)
                 .send()
@@ -966,11 +972,19 @@ mod test {
     #[test]
     fn debug_and_clone() {
         let device: QRydAPIDevice = QrydEmuSquareDevice::new(None, None, None).into();
-        let backend =
-            APIBackend::new(device.clone(), Some("".to_string()), Some(2), None, None).unwrap();
+        let backend = APIBackend::new(
+            device.clone(),
+            Some("".to_string()),
+            Some(2),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let a = format!("{:?}", backend);
         assert!(a.contains("QrydEmuSquareDevice"));
-        let backend2 = APIBackend::new(device, Some("a".to_string()), Some(2), None, None).unwrap();
+        let backend2 =
+            APIBackend::new(device, Some("a".to_string()), Some(2), None, None, None).unwrap();
         assert_eq!(backend.clone(), backend);
         assert_ne!(backend, backend2);
     }
@@ -1088,7 +1102,8 @@ mod test {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -1173,7 +1188,8 @@ mod test {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -1240,7 +1256,8 @@ mod test {
             .collect::<String>();
         let device = QrydEmuSquareDevice::new(Some(1), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
 
         let mut input_circuit = Circuit::new();
         input_circuit += operations::DefinitionBit::new("ro".to_string(), 3, true);

--- a/roqoqo-qryd/src/api_devices.rs
+++ b/roqoqo-qryd/src/api_devices.rs
@@ -41,10 +41,10 @@ impl QRydAPIDevice {
     }
 
     /// Returns the seed usized for the API.
-    pub fn seed(&self) -> usize {
+    pub fn seed(&self) -> Option<usize> {
         match self {
-            Self::QrydEmuSquareDevice(x) => x.seed(),
-            Self::QrydEmuTriangularDevice(x) => x.seed(),
+            Self::QrydEmuSquareDevice(x) => Some(x.seed()),
+            Self::QrydEmuTriangularDevice(x) => Some(x.seed()),
             Self::TweezerDevice(x) => x.seed(),
         }
     }

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -210,6 +210,7 @@ impl TweezerDevice {
     ///                         or set via the environmental variable `$QRYD_API_TOKEN`.
     /// * `mock_port` - The address of the Mock server, used for testing purposes.
     /// * `seed` - Optionally overwrite seed value from downloaded device instance.
+    /// * `dev` - The boolean to set the dev header to.
     /// * `api_version` - The version of the QRYD API to use. Defaults to "v1_0".
     ///
     /// # Returns
@@ -225,6 +226,7 @@ impl TweezerDevice {
         access_token: Option<String>,
         mock_port: Option<String>,
         seed: Option<usize>,
+        dev: Option<bool>,
         api_version: Option<String>,
     ) -> Result<Self, RoqoqoBackendError> {
         // Preparing variables
@@ -263,6 +265,19 @@ impl TweezerDevice {
             client
                 .get(format!("http://127.0.0.1:{}", port))
                 .body(device_name_internal)
+                .send()
+                .map_err(|e| RoqoqoBackendError::NetworkError {
+                    msg: format!("{:?}", e),
+                })?
+        } else if dev.unwrap_or(false) {
+            client
+                .get(format!(
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    api_version.unwrap_or_else(|| String::from("v1_0")),
+                    device_name_internal
+                ))
+                .header("X-API-KEY", access_token_internal)
+                .header("X-DEV", "?1")
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
                     msg: format!("{:?}", e),

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -47,8 +47,8 @@ pub struct TweezerDevice {
     pub controlled_phase_phase_relation: String,
     /// The default layout to use at first intantiation.
     pub default_layout: Option<String>,
-    /// Seed, if not provided will be set to 0 per default (not recommended!)
-    seed: usize,
+    /// Optional seed, for simulation purposes.
+    seed: Option<usize>,
 }
 
 /// Tweezers information relative to a Layout
@@ -167,7 +167,7 @@ impl TweezerDevice {
     ///
     /// # Arguments
     ///
-    /// * `seed` - Seed, if not provided will be set to 0 by default (not recommended!)
+    /// * `seed` - Optional seed, for simulation purposes.
     /// * `controlled_z_phase_relation` - The relation to use for the PhaseShiftedControlledZ gate.
     ///                                   It can be hardcoded to a specific value if a float is passed in as String.
     /// * `controlled_phase_phase_relation` - The relation to use for the PhaseShiftedControlledPhase gate.
@@ -194,7 +194,7 @@ impl TweezerDevice {
             controlled_z_phase_relation,
             controlled_phase_phase_relation,
             default_layout: None,
-            seed: seed.unwrap_or_default(),
+            seed,
         }
     }
 
@@ -286,7 +286,7 @@ impl TweezerDevice {
                 device.switch_layout(&default).unwrap();
             }
             if let Some(new_seed) = seed {
-                device.seed = new_seed;
+                device.seed = Some(new_seed);
             }
             Ok(device)
         } else {
@@ -1007,7 +1007,7 @@ impl TweezerDevice {
     }
 
     /// Returns the seed usized for the API.
-    pub fn seed(&self) -> usize {
+    pub fn seed(&self) -> Option<usize> {
         self.seed
     }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -204,12 +204,13 @@ impl TweezerDevice {
     ///
     /// # Arguments
     ///
-    /// * `device_name` - The name of the device to instantiate. Defaults to "Default".
+    /// * `device_name` - The name of the device to instantiate. Defaults to "test_device".
     /// * `access_token` - An access_token is required to access QRYD hardware and emulators.
     ///                    The access_token can either be given as an argument here
     ///                         or set via the environmental variable `$QRYD_API_TOKEN`.
     /// * `mock_port` - The address of the Mock server, used for testing purposes.
     /// * `seed` - Optionally overwrite seed value from downloaded device instance.
+    /// * `api_version` - The version of the QRYD API to use. Defaults to "v1_0".
     ///
     /// # Returns
     ///
@@ -224,6 +225,7 @@ impl TweezerDevice {
         access_token: Option<String>,
         mock_port: Option<String>,
         seed: Option<usize>,
+        api_version: Option<String>,
     ) -> Result<Self, RoqoqoBackendError> {
         // Preparing variables
         let device_name_internal = device_name.unwrap_or_else(|| String::from("testdevice"));
@@ -268,7 +270,8 @@ impl TweezerDevice {
         } else {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/v1_0/backends/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    api_version.unwrap_or_else(|| String::from("v1_0")),
                     device_name_internal
                 ))
                 .header("X-API-KEY", access_token_internal)

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -209,6 +209,7 @@ impl TweezerDevice {
     ///                    The access_token can either be given as an argument here
     ///                         or set via the environmental variable `$QRYD_API_TOKEN`.
     /// * `mock_port` - The address of the Mock server, used for testing purposes.
+    /// * `seed` - Optionally overwrite seed value from downloaded device instance.
     ///
     /// # Returns
     ///
@@ -222,9 +223,10 @@ impl TweezerDevice {
         device_name: Option<String>,
         access_token: Option<String>,
         mock_port: Option<String>,
+        seed: Option<usize>,
     ) -> Result<Self, RoqoqoBackendError> {
         // Preparing variables
-        let device_name_internal = device_name.unwrap_or_else(|| String::from("default"));
+        let device_name_internal = device_name.unwrap_or_else(|| String::from("testdevice"));
         let access_token_internal: String = if mock_port.is_some() {
             "".to_string()
         } else {
@@ -282,6 +284,9 @@ impl TweezerDevice {
             let mut device = resp.json::<TweezerDevice>().unwrap();
             if let Some(default) = device.default_layout.clone() {
                 device.switch_layout(&default).unwrap();
+            }
+            if let Some(new_seed) = seed {
+                device.seed = new_seed;
             }
             Ok(device)
         } else {

--- a/roqoqo-qryd/tests/integration/api_backend.rs
+++ b/roqoqo-qryd/tests/integration/api_backend.rs
@@ -35,7 +35,7 @@ fn api_backend() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None, None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -168,7 +168,8 @@ fn api_backend() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
         circuit += operations::RotateX::new(0, std::f64::consts::PI.into());
@@ -260,7 +261,7 @@ fn api_backend_failing() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None, None).unwrap();
         // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
@@ -291,7 +292,7 @@ fn api_backend_with_constant_circuit() {
         let number_qubits = 6;
         let device = QrydEmuSquareDevice::new(Some(2), None, None);
         let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None, None).unwrap();
         // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
         let mut circuit = Circuit::new();
         circuit += operations::DefinitionBit::new("ro".to_string(), number_qubits, true);
@@ -411,7 +412,7 @@ fn api_triangular() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None, None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
         assert!(!job_loc.is_empty());
@@ -493,7 +494,8 @@ fn api_triangular() {
             )
             .create();
 
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
         assert!(!job_loc.is_empty());
@@ -512,6 +514,7 @@ fn api_triangular() {
         mock_result.assert();
     }
 }
+
 #[test]
 fn evaluating_backend() {
     let number_qubits = 6;
@@ -547,7 +550,8 @@ fn evaluating_backend() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, Some(20), None, None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, Some(20), None, None, None).unwrap();
 
         let program_result = program.run(api_backend_new, &[]).unwrap().unwrap();
         assert_eq!(program_result.get("test"), Some(&-3.0));
@@ -617,7 +621,7 @@ fn evaluating_backend() {
             .create();
 
         let api_backend_new =
-            APIBackend::new(qryd_device, None, Some(20), Some(port), None).unwrap();
+            APIBackend::new(qryd_device, None, Some(20), Some(port), None, None).unwrap();
 
         let program_result = program.run(api_backend_new.clone(), &[]).unwrap().unwrap();
 
@@ -738,7 +742,7 @@ fn api_delete() {
     };
 
     if env::var("QRYD_API_TOKEN").is_ok() {
-        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None).unwrap();
+        let api_backend_new = APIBackend::new(qryd_device, None, None, None, None, None).unwrap();
 
         let job_loc = api_backend_new
             .post_job(
@@ -770,7 +774,8 @@ fn api_delete() {
             .mock("DELETE", mockito::Matcher::Any)
             .with_status(200)
             .create();
-        let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+        let api_backend_new =
+            APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
 
         let job_loc = api_backend_new.post_job(program).unwrap();
 
@@ -789,7 +794,7 @@ fn api_backend_errorcase_const() {
     let device = QrydEmuSquareDevice::new(Some(2), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -801,7 +806,7 @@ fn api_backend_errorcase_const() {
             .chars()
             .rev()
             .collect::<String>();
-        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap()
     };
     // // CAUTION: environment variable QRYD_API_TOKEN needs to be set on the terminal to pass this test!
     let qubit_mapping: HashMap<usize, usize> = (0..number_qubits).map(|x| (x, x)).collect();
@@ -831,7 +836,7 @@ fn api_backend_errorcase3() {
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
 
     if env::var("QRYD_API_TOKEN").is_err() {
-        let api_backend_err = APIBackend::new(qryd_device.clone(), None, None, None, None);
+        let api_backend_err = APIBackend::new(qryd_device.clone(), None, None, None, None, None);
         assert!(api_backend_err.is_err());
         assert_eq!(
             api_backend_err.unwrap_err(),
@@ -843,6 +848,7 @@ fn api_backend_errorcase3() {
     let api_backend_new = APIBackend::new(
         qryd_device,
         Some("DummyString".to_string()),
+        None,
         None,
         None,
         None,
@@ -884,7 +890,7 @@ fn api_backend_errorcase4() {
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
 
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -896,7 +902,7 @@ fn api_backend_errorcase4() {
             .chars()
             .rev()
             .collect::<String>();
-        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap()
     };
     let job_loc: String = "DummyString".to_string();
     let job_status = api_backend_new.get_job_status(job_loc.clone());
@@ -915,7 +921,7 @@ fn api_backend_errorcase5() {
     let device = QrydEmuSquareDevice::new(Some(2), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
     let api_backend_new: APIBackend = if env::var("QRYD_API_TOKEN").is_ok() {
-        APIBackend::new(qryd_device, None, None, None, None).unwrap()
+        APIBackend::new(qryd_device, None, None, None, None, None).unwrap()
     } else {
         let server = Server::new();
         let port = server
@@ -928,7 +934,7 @@ fn api_backend_errorcase5() {
             .rev()
             .collect::<String>();
 
-        APIBackend::new(qryd_device, None, None, Some(port), None).unwrap()
+        APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap()
     };
     let measurement = ClassicalRegister {
         constant_circuit: None,
@@ -1008,7 +1014,7 @@ fn api_backend_errorcase6() {
         .create();
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
@@ -1056,8 +1062,15 @@ fn api_backend_errorcase6() {
 fn api_backend_errorcase7() {
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-    let api_backend_new =
-        APIBackend::new(qryd_device, None, None, Some("12345".to_string()), None).unwrap();
+    let api_backend_new = APIBackend::new(
+        qryd_device,
+        None,
+        None,
+        Some("12345".to_string()),
+        None,
+        None,
+    )
+    .unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
@@ -1141,7 +1154,7 @@ fn api_backend_errorcase8() {
 
     let device = QrydEmuSquareDevice::new(Some(1), None, None);
     let qryd_device: QRydAPIDevice = QRydAPIDevice::from(&device);
-    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None).unwrap();
+    let api_backend_new = APIBackend::new(qryd_device, None, None, Some(port), None, None).unwrap();
     let mut circuit = Circuit::new();
     circuit += operations::DefinitionBit::new("ro".to_string(), 6, true);
     circuit += operations::RotateX::new(0, std::f64::consts::FRAC_PI_2.into());

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -22,7 +22,7 @@ fn test_new_square() {
     let device = QrydEmuSquareDevice::new(None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), 0);
-    assert_eq!(device.seed(), apidevice.seed());
+    assert_eq!(device.seed(), apidevice.seed().unwrap());
     assert_eq!(device.qrydbackend(), "qryd_emu_cloudcomp_square");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
@@ -33,7 +33,7 @@ fn test_new_triangular() {
     let device = QrydEmuTriangularDevice::new(Some(1), None, None, None, None);
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), 1);
-    assert_eq!(device.seed(), apidevice.seed());
+    assert_eq!(device.seed(), apidevice.seed().unwrap());
     assert_eq!(device.qrydbackend(), "qryd_emu_cloudcomp_triangle");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
@@ -43,7 +43,7 @@ fn test_new_triangular() {
 fn test_new_tweezer() {
     let device = TweezerDevice::new(Some(1), None, None);
     let apidevice = QRydAPIDevice::from(&device);
-    assert_eq!(device.seed(), 1);
+    assert_eq!(device.seed(), Some(1));
     assert_eq!(device.seed(), apidevice.seed());
     assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -587,14 +587,21 @@ fn test_from_api() {
                 .unwrap()
                 .into_bytes(),
         )
+        .expect(2)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port.clone()));
-    mock.assert();
+    let response = TweezerDevice::from_api(None, None, Some(port.clone()), None);
     assert!(response.is_ok());
 
     let device = response.unwrap();
     assert_eq!(device, returned_device_default);
+
+    let response_new_seed = TweezerDevice::from_api(None, None, Some(port.clone()), Some(42));
+    mock.assert();
+    assert!(response_new_seed.is_ok());
+
+    let device_new_seed = response_new_seed.unwrap();
+    assert_eq!(device_new_seed.seed(), 42);
 
     mock.remove();
     mock = server
@@ -602,7 +609,7 @@ fn test_from_api() {
         .with_status(400)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port));
+    let response = TweezerDevice::from_api(None, None, Some(port), None);
     mock.assert();
     assert!(response.is_err());
     assert_eq!(

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -31,8 +31,12 @@ fn test_new() {
     assert!(device.qubit_to_tweezer.is_none());
     assert_eq!(device.layout_register.len(), 1);
     assert!(device.layout_register.get("default").is_some());
-    assert_eq!(device.seed(), 2);
+    assert_eq!(device.seed(), Some(2));
     assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
+
+    let device_emp = TweezerDevice::new(None, None, None);
+
+    assert_eq!(device_emp.seed(), None);
 }
 
 // Test TweezerDevice add_layout(), switch_layout() methods
@@ -601,7 +605,7 @@ fn test_from_api() {
     assert!(response_new_seed.is_ok());
 
     let device_new_seed = response_new_seed.unwrap();
-    assert_eq!(device_new_seed.seed(), 42);
+    assert_eq!(device_new_seed.seed(), Some(42));
 
     mock.remove();
     mock = server

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -594,13 +594,14 @@ fn test_from_api() {
         .expect(2)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port.clone()), None, None);
+    let response = TweezerDevice::from_api(None, None, Some(port.clone()), None, None, None);
     assert!(response.is_ok());
 
     let device = response.unwrap();
     assert_eq!(device, returned_device_default);
 
-    let response_new_seed = TweezerDevice::from_api(None, None, Some(port.clone()), Some(42), None);
+    let response_new_seed =
+        TweezerDevice::from_api(None, None, Some(port.clone()), Some(42), None, None);
     mock.assert();
     assert!(response_new_seed.is_ok());
 
@@ -613,7 +614,7 @@ fn test_from_api() {
         .with_status(400)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port), None, None);
+    let response = TweezerDevice::from_api(None, None, Some(port), None, None, None);
     mock.assert();
     assert!(response.is_err());
     assert_eq!(

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -594,13 +594,13 @@ fn test_from_api() {
         .expect(2)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port.clone()), None);
+    let response = TweezerDevice::from_api(None, None, Some(port.clone()), None, None);
     assert!(response.is_ok());
 
     let device = response.unwrap();
     assert_eq!(device, returned_device_default);
 
-    let response_new_seed = TweezerDevice::from_api(None, None, Some(port.clone()), Some(42));
+    let response_new_seed = TweezerDevice::from_api(None, None, Some(port.clone()), Some(42), None);
     mock.assert();
     assert!(response_new_seed.is_ok());
 
@@ -613,7 +613,7 @@ fn test_from_api() {
         .with_status(400)
         .create();
 
-    let response = TweezerDevice::from_api(None, None, Some(port), None);
+    let response = TweezerDevice::from_api(None, None, Some(port), None, None);
     mock.assert();
     assert!(response.is_err());
     assert_eq!(


### PR DESCRIPTION
- Added `api_version`, `seed`, `dev` parameters to `TweezerDevice.from_api()`
- Fixed `TweezerDevice` support for `APIBackend`
- Modified `TweezerDevice` seed parameter to default to None, instead of 0
- Added `api_version` parameter to `APIBackend`
- Added "format" field in QRydRunData