### PR TITLE
PragmaActiveReset Support, better APIBackend-TweezerDevice Support

### DIFF
--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -24,7 +24,7 @@ jobs:
       # Run tests also on windows runners
       windows: true
       # Run tests also on macos runners
-      macos: false
+      macos: true
       py_interface_folder: "qoqo-qryd"
       has_python_tests: false
 

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -22,9 +22,9 @@ jobs:
     uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@main
     with: 
       # Run tests also on windows runners
-      windows: false
+      windows: true
       # Run tests also on macos runners
-      macos: false
+      macos: true
       py_interface_folder: "qoqo-qryd"
       has_python_tests: false
 

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -19,12 +19,12 @@ jobs:
       test_code_coverage: false
   
   build_tests:
-    uses: mlodi-hqs/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@macos_fix
+    uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@main
     with: 
       # Run tests also on windows runners
       windows: true
       # Run tests also on macos runners
-      macos: true
+      macos: false
       py_interface_folder: "qoqo-qryd"
       has_python_tests: false
 

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -19,12 +19,12 @@ jobs:
       test_code_coverage: false
   
   build_tests:
-    uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@main
+    uses: mlodi-hqs/reusable_workflows/.github/workflows/reusable_build_tests_rust_pyo3.yml@macos_fix
     with: 
       # Run tests also on windows runners
       windows: true
       # Run tests also on macos runners
-      macos: true
+      macos: false
       py_interface_folder: "qoqo-qryd"
       has_python_tests: false
 

--- a/.github/workflows/hqs-ci-test-rust-pyo3.yml
+++ b/.github/workflows/hqs-ci-test-rust-pyo3.yml
@@ -24,7 +24,7 @@ jobs:
       # Run tests also on windows runners
       windows: false
       # Run tests also on macos runners
-      macos: true
+      macos: false
       py_interface_folder: "qoqo-qryd"
       has_python_tests: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.11.5
+
+* Modified `TweezerDevice.from_api()` endpoint
+
 # 0.11.4
 
 * Added `api_version`, `seed`, `dev` parameters to `TweezerDevice.from_api()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Tracks qoqo-qryd changes after 0.5
 # 0.11.5
 
 * Modified `TweezerDevice.from_api()` endpoint
+* Added support for `PragmaActiveReset` for `APIBackend`, `TweezerDevice`
 
 # 0.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.11.5
 
-* Modified `TweezerDevice.from_api()` endpoint
+* Modified `TweezerDevice.from_api()` endpoint, default device name for better `APIBackend` support
 * Added support for `PragmaActiveReset` for `APIBackend`, `TweezerDevice`
 
 # 0.11.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bincode"
@@ -204,9 +204,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -229,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -246,15 +246,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -263,21 +263,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -402,7 +402,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
@@ -467,9 +467,9 @@ checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
@@ -1108,17 +1108,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1223,9 +1222,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
  "ring",
@@ -1244,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1299,9 +1298,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1309,18 +1308,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1415,9 +1414,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -1425,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1435,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "struqture"
@@ -1632,7 +1631,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
@@ -1660,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1738,9 +1737,9 @@ checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hermit-abi"
@@ -450,7 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -509,9 +509,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bincode",
  "mockito",
@@ -1030,18 +1030,18 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bincode",
  "bitvec",
@@ -1543,9 +1543,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "test-case"
@@ -1584,18 +1584,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1680,20 +1680,19 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -1859,9 +1858,9 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "wide"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebecebefc38ff1860b4bc47550bbfa63af5746061cf0d29fcd7fa63171602598"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/documentation/src/qrydspecifics.md
+++ b/documentation/src/qrydspecifics.md
@@ -11,7 +11,7 @@ Note that all functionality described here is a preview and does not represent a
 Special operations
 ------------------
 
-To support the full flexibility of the QRydDemo devices, two additional qoqo operations are provided ``PragmaChangeQRydLayout``, ``PragmaSwitchDeviceLayout``, ``PragmaShiftQRydQubit`` and ``PragmaShiftQubitsTweezers``.
+To support the full flexibility of the QRydDemo devices, four additional qoqo operations are provided ``PragmaChangeQRydLayout``, ``PragmaSwitchDeviceLayout``, ``PragmaShiftQRydQubit`` and ``PragmaShiftQubitsTweezers``.
 ``PragmaChangeQRydLayout`` allows a quantum circuit to change between predefined calibrated optical tweezer positions. It indexes the layouts by integer. A similar operation, but meant for ``TweezerDevice`` and ``TweezerMutableDevice``, is ``PragmaSwitchDeviceLayout``, which indexes the new layout via a string.
 ``PragmaShiftQRydQubit`` allows a quantum circuit to shift a qubit from one tweezer position to another. ``PragmaShiftQubitsTweezers`` is the equivalent operation meant to be used with ``TweezerDevice`` and ``TweezerMutableDevice``.
 

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
   'numpy',
   'qoqo>=1.6',

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -1276,7 +1276,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-base64 0.21.4
+base64 0.21.5
 https://github.com/marshallpierce/rust-base64
 by Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>
 encodes and decodes base64 as bytes or utf8
@@ -4890,7 +4890,7 @@ SOFTWARE.
 
 
 ====================================================
-futures 0.3.28
+futures 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 An implementation of futures and streams featuring zero allocations,
@@ -5135,7 +5135,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-channel 0.3.28
+futures-channel 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 Channels for asynchronous communication using futures-rs.
@@ -5379,7 +5379,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-core 0.3.28
+futures-core 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 The core traits and types in for the `futures` library.
@@ -5623,7 +5623,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-executor 0.3.28
+futures-executor 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 Executors for asynchronous tasks based on the futures-rs library.
@@ -5867,7 +5867,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-io 0.3.28
+futures-io 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library.
@@ -6111,7 +6111,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-macro 0.3.28
+futures-macro 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 The futures-rs procedural macro implementations.
@@ -6355,7 +6355,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-sink 0.3.28
+futures-sink 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 The asynchronous `Sink` trait for the futures-rs library.
@@ -6599,7 +6599,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-task 0.3.28
+futures-task 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 Tools for working with tasks.
@@ -6843,7 +6843,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-futures-util 0.3.28
+futures-util 0.3.29
 https://rust-lang.github.io/futures-rs
 by 
 Common utilities and extension traits for the futures-rs library.
@@ -9344,7 +9344,7 @@ THE SOFTWARE.
 
 
 ====================================================
-hyper-rustls 0.24.1
+hyper-rustls 0.24.2
 https://github.com/rustls/hyper-rustls
 by 
 Rustls+hyper integration for pure rust HTTPS
@@ -10769,7 +10769,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-ipnet 2.8.0
+ipnet 2.9.0
 https://github.com/krisprice/ipnet
 by Kris Price <kris@krisprice.nz>
 Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain.
@@ -13463,7 +13463,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 
 ====================================================
-mio 0.8.8
+mio 0.8.9
 https://github.com/tokio-rs/mio
 by Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>
 Lightweight non-blocking I/O.
@@ -23433,7 +23433,7 @@ THE SOFTWARE.
 
 
 ====================================================
-ring 0.16.20
+ring 0.17.5
 https://github.com/briansmith/ring
 by Brian Smith <brian@briansmith.org>
 Safe, fast, small crypto using Rust.
@@ -24979,7 +24979,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-rustls 0.21.7
+rustls 0.21.8
 https://github.com/rustls/rustls
 by 
 Rustls is a modern TLS library written in Rust.
@@ -25513,7 +25513,7 @@ THIS SOFTWARE.
 
 
 ====================================================
-rustls-webpki 0.101.6
+rustls-webpki 0.101.7
 https://github.com/rustls/webpki
 by 
 Web PKI X.509 Certificate Verification.
@@ -26167,11 +26167,11 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-sct 0.7.0
-https://github.com/ctz/sct.rs
+sct 0.7.1
+https://github.com/rustls/sct.rs
 by Joseph Birr-Pixton <jpixton@gmail.com>
 Certificate transparency SCT verification library
-License: Apache-2.0/ISC/MIT
+License: Apache-2.0 OR ISC OR MIT
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -26441,7 +26441,7 @@ THIS SOFTWARE.
 
 
 ====================================================
-serde 1.0.189
+serde 1.0.190
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A generic serialization/deserialization framework
@@ -26655,7 +26655,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_derive 1.0.189
+serde_derive 1.0.190
 https://serde.rs
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 Macros 1.1 implementation of #[derive(Serialize, Deserialize)]
@@ -28694,7 +28694,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-socket2 0.4.9
+socket2 0.4.10
 https://github.com/rust-lang/socket2
 by Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>
 Utilities for handling networking sockets with a maximal amount of configuration
@@ -28937,7 +28937,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-socket2 0.5.4
+socket2 0.5.5
 https://github.com/rust-lang/socket2
 by Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>
 Utilities for handling networking sockets with a maximal amount of configuration
@@ -29180,13 +29180,10 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-spin 0.5.2
+spin 0.9.8
 https://github.com/mvdnes/spin-rs.git
-by Mathijs van de Nes <git@mathijs.vd-nes.nl>, John Ericson <git@JohnEricson.me>
-Synchronization primitives based on spinning.
-They may contain data, are usable without `std`,
-and static initializers are available.
-
+by Mathijs van de Nes <git@mathijs.vd-nes.nl>, John Ericson <git@JohnEricson.me>, Joshua Barretto <joshua.s.barretto@gmail.com>
+Spin-based synchronization primitives
 License: MIT
 ----------------------------------------------------
 LICENSE:
@@ -31733,7 +31730,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-tokio-util 0.7.9
+tokio-util 0.7.10
 https://tokio.rs
 by Tokio Contributors <team@tokio.rs>
 Additional utilities for working with Tokio.
@@ -33145,7 +33142,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-untrusted 0.7.1
+untrusted 0.9.0
 https://github.com/briansmith/untrusted
 by Brian Smith <brian@briansmith.org>
 Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust.

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -7847,7 +7847,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-hashbrown 0.14.1
+hashbrown 0.14.2
 https://github.com/rust-lang/hashbrown
 by Amanieu d'Antras <amanieu@gmail.com>
 A Rust port of Google's SwissTable hash map
@@ -12148,7 +12148,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-lock_api 0.4.10
+lock_api 0.4.11
 https://github.com/Amanieu/parking_lot
 by Amanieu d'Antras <amanieu@gmail.com>
 Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.
@@ -15944,7 +15944,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-parking_lot_core 0.9.8
+parking_lot_core 0.9.9
 https://github.com/Amanieu/parking_lot
 by Amanieu d'Antras <amanieu@gmail.com>
 An advanced API for creating custom synchronization primitives.
@@ -20119,7 +20119,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.11.4
+qoqo-qryd 0.11.5
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -22439,7 +22439,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-redox_syscall 0.3.5
+redox_syscall 0.4.1
 https://gitlab.redox-os.org/redox-os/syscall
 by Jeremy Soller <jackpot51@gmail.com>
 A Rust library to access raw Redox system calls
@@ -22472,7 +22472,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex 1.10.0
+regex 1.10.2
 https://github.com/rust-lang/regex
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 An implementation of regular expressions for Rust. This implementation uses
@@ -22715,7 +22715,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-automata 0.4.1
+regex-automata 0.4.3
 https://github.com/rust-lang/regex/tree/master/regex-automata
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 Automata construction and matching using regular expressions.
@@ -22956,7 +22956,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-syntax 0.8.1
+regex-syntax 0.8.2
 https://github.com/rust-lang/regex/tree/master/regex-syntax
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 A regular expression parser.
@@ -23862,7 +23862,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.11.4
+roqoqo-qryd 0.11.5
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit
@@ -30141,7 +30141,7 @@ SOFTWARE.
 
 
 ====================================================
-target-lexicon 0.12.11
+target-lexicon 0.12.12
 https://github.com/bytecodealliance/target-lexicon
 by Dan Gohman <sunfish@mozilla.com>
 Targeting utilities for compilers and related tools
@@ -30468,7 +30468,7 @@ SOFTWARE.
 
 
 ====================================================
-thiserror 1.0.49
+thiserror 1.0.50
 https://github.com/dtolnay/thiserror
 by David Tolnay <dtolnay@gmail.com>
 derive(Error)
@@ -30682,7 +30682,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-thiserror-impl 1.0.49
+thiserror-impl 1.0.50
 https://github.com/dtolnay/thiserror
 by David Tolnay <dtolnay@gmail.com>
 Implementation detail of the `thiserror` crate
@@ -31807,7 +31807,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-tracing 0.1.37
+tracing 0.1.40
 https://tokio.rs
 by Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>
 Application-level tracing for Rust.
@@ -31844,7 +31844,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-tracing-core 0.1.31
+tracing-core 0.1.32
 https://tokio.rs
 by Tokio Contributors <team@tokio.rs>
 Core primitives for application-level tracing.
@@ -35865,7 +35865,7 @@ one at http://mozilla.org/MPL/2.0/.
 
 
 ====================================================
-wide 0.7.12
+wide 0.7.13
 https://github.com/Lokathor/wide
 by Lokathor <zefria@gmail.com>
 A crate to help you go wide.

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1208,6 +1208,7 @@ impl TweezerMutableDeviceWrapper {
     ///
     /// Args:
     ///     allow_reset(bool): Whether the device should allow PragmaActiveReset operations or not.
+    #[pyo3(text_signature = "(allow_reset, /)")]
     pub fn set_allow_reset(&mut self, allow_reset: bool) {
         self.internal.set_allow_reset(allow_reset);
     }

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -1204,6 +1204,14 @@ impl TweezerMutableDeviceWrapper {
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
+    /// Set whether the device allows PragmaActiveReset operations or not.
+    ///
+    /// Args:
+    ///     allow_reset(bool): Whether the device should allow PragmaActiveReset operations or not.
+    pub fn set_allow_reset(&mut self, allow_reset: bool) {
+        self.internal.set_allow_reset(allow_reset);
+    }
+
     /// Set the name of the default layout to use and switch to it.
     ///
     /// Args:

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -44,7 +44,7 @@ fn test_new() {
                 .unwrap()
                 .extract::<String>()
                 .unwrap(),
-            "testdevice"
+            "qryd_tweezer_device"
         );
         assert_eq!(
             res_mut
@@ -52,7 +52,7 @@ fn test_new() {
                 .unwrap()
                 .extract::<String>()
                 .unwrap(),
-            "testdevice"
+            "qryd_tweezer_device"
         );
         assert_eq!(
             res.call_method0("seed")

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -44,7 +44,7 @@ fn test_new() {
                 .unwrap()
                 .extract::<String>()
                 .unwrap(),
-            "qryd_tweezer_device"
+            "testdevice"
         );
         assert_eq!(
             res_mut
@@ -52,7 +52,7 @@ fn test_new() {
                 .unwrap()
                 .extract::<String>()
                 .unwrap(),
-            "qryd_tweezer_device"
+            "testdevice"
         );
         assert_eq!(
             res.call_method0("seed")
@@ -306,6 +306,18 @@ fn test_allowed_tweezer_shifts_from_rows() {
         assert!(device_mut
             .call_method1("set_allowed_tweezer_shifts_from_rows", (vec![vec![0, 0]],))
             .is_err());
+    })
+}
+
+/// Test allow_reset for TweezerMutableDeviceWrapper
+#[test]
+fn test_allow_reset() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let device_type_mut = py.get_type::<TweezerMutableDeviceWrapper>();
+        let device_mut = device_type_mut.call0().unwrap();
+
+        assert!(device_mut.call_method1("set_allow_reset", (true,)).is_ok());
     })
 }
 

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -232,9 +232,10 @@ fn check_operation_compatability(op: &Operation) -> Result<(), RoqoqoBackendErro
         Operation::ISwap(_) => Ok(()),
         Operation::PragmaSetNumberOfMeasurements(_) => Ok(()),
         Operation::PragmaRepeatedMeasurement(_) => Ok(()),
+        Operation::PragmaActiveReset(_) => Ok(()),
         _ => Err(RoqoqoBackendError::GenericError {
             msg: format!("Operation {} is not supported by QRydDemo Web API backend.\n
-            Use: MeasureQubit, PragmaSetNumberOfMeasurements, PragmaRepeatedMeasurement, PhaseShiftState1, RotateXY, RotateX, RotateY, RotateZ, RotateZ, Hadamard, PauliX, PauliY, PauliZ, SqrtPauliX, InvSqrtPauliX, PhaseShiftedControlledZ, PhaseShiftedControlledPhase, CNOT, ControlledPauliY, ControlledPauliZ, ControlledPhaseShift, PragmaControlledCircuit, ControlledControlledPauliZ, ControlledControlledPhaseShift, SWAP or ISwap instead.", op.hqslang())
+            Use: MeasureQubit, PragmaSetNumberOfMeasurements, PragmaRepeatedMeasurement, PragmaActiveReset, PhaseShiftState1, RotateXY, RotateX, RotateY, RotateZ, RotateZ, Hadamard, PauliX, PauliY, PauliZ, SqrtPauliX, InvSqrtPauliX, PhaseShiftedControlledZ, PhaseShiftedControlledPhase, CNOT, ControlledPauliY, ControlledPauliZ, ControlledPhaseShift, PragmaControlledCircuit, ControlledControlledPauliZ, ControlledControlledPhaseShift, SWAP or ISwap instead.", op.hqslang())
         })
     }
 }

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -521,7 +521,7 @@ impl APIBackend {
             use_reverse_traversal: true,
             extended_set_size: 5,
             extended_set_weight: 0.5,
-            reverse_traversal_iterations: 2,
+            reverse_traversal_iterations: 3,
         };
 
         // Prepare WebAPI client

--- a/roqoqo-qryd/src/api_backend.rs
+++ b/roqoqo-qryd/src/api_backend.rs
@@ -1374,7 +1374,7 @@ mod test {
             seed_compiler: None,
             use_extended_set: true,
             use_reverse_traversal: true,
-            reverse_traversal_iterations: 2,
+            reverse_traversal_iterations: 3,
         };
 
         let mock = server

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -1226,15 +1226,6 @@ impl Device for TweezerDevice {
                     }),
                 }
             },
-            "PragmaActiveReset" => {
-                if self.allow_reset {
-                    Ok(())
-                } else {
-                    Err(RoqoqoBackendError::GenericError {
-                        msg: "The TweezerDevice instance does not support PragmaActiveReset operations.".to_string(),
-                    })
-                }
-            },
             _ => Err(RoqoqoBackendError::GenericError {
                 msg: "Wrapped operation not supported in TweezerDevice".to_string(),
             }),

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -278,7 +278,7 @@ impl TweezerDevice {
         } else if dev.unwrap_or(false) {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
                     device_name_internal.clone()
                 ))
@@ -291,7 +291,7 @@ impl TweezerDevice {
         } else {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
                     device_name_internal.clone()
                 ))

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -51,6 +51,8 @@ pub struct TweezerDevice {
     seed: Option<usize>,
     /// Whether to allow PragmaActiveReset operations on the device.
     pub allow_reset: bool,
+    /// Device name.
+    pub device_name: String,
 }
 
 /// Tweezers information relative to a Layout
@@ -198,6 +200,7 @@ impl TweezerDevice {
             default_layout: None,
             seed,
             allow_reset: false,
+            device_name: String::from("qryd_tweezer_device"),
         }
     }
 
@@ -267,7 +270,7 @@ impl TweezerDevice {
         let resp = if let Some(port) = mock_port {
             client
                 .get(format!("http://127.0.0.1:{}", port))
-                .body(device_name_internal)
+                .body(device_name_internal.clone())
                 .send()
                 .map_err(|e| RoqoqoBackendError::NetworkError {
                     msg: format!("{:?}", e),
@@ -275,9 +278,9 @@ impl TweezerDevice {
         } else if dev.unwrap_or(false) {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
-                    device_name_internal
+                    device_name_internal.clone()
                 ))
                 .header("X-API-KEY", access_token_internal)
                 .header("X-DEV", "?1")
@@ -288,9 +291,9 @@ impl TweezerDevice {
         } else {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
-                    device_name_internal
+                    device_name_internal.clone()
                 ))
                 .header("X-API-KEY", access_token_internal)
                 .send()
@@ -309,6 +312,7 @@ impl TweezerDevice {
             if let Some(new_seed) = seed {
                 device.seed = Some(new_seed);
             }
+            device.device_name = device_name_internal;
             Ok(device)
         } else {
             Err(RoqoqoBackendError::NetworkError {
@@ -1043,7 +1047,7 @@ impl TweezerDevice {
 
     /// Returns the backend associated with the device.
     pub fn qrydbackend(&self) -> String {
-        "testdevice".to_string()
+        self.device_name.clone()
     }
 }
 

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -49,6 +49,8 @@ pub struct TweezerDevice {
     pub default_layout: Option<String>,
     /// Optional seed, for simulation purposes.
     seed: Option<usize>,
+    /// Whether to allow PragmaActiveReset operations on the device.
+    allow_reset: bool,
 }
 
 /// Tweezers information relative to a Layout
@@ -195,6 +197,7 @@ impl TweezerDevice {
             controlled_phase_phase_relation,
             default_layout: None,
             seed,
+            allow_reset: false,
         }
     }
 
@@ -662,6 +665,15 @@ impl TweezerDevice {
         Ok(())
     }
 
+    /// Set whether the device allows PragmaActiveReset operations or not.
+    ///
+    /// # Arguments
+    ///
+    /// * `allow_reset` - Whether the device should allow PragmaActiveReset operations or not.
+    pub fn set_allow_reset(&mut self, allow_reset: bool) {
+        self.allow_reset = allow_reset
+    }
+
     /// Set the name of the default layout to use and switch to it.
     ///
     /// # Arguments
@@ -1031,7 +1043,7 @@ impl TweezerDevice {
 
     /// Returns the backend associated with the device.
     pub fn qrydbackend(&self) -> String {
-        "qryd_tweezer_device".to_string()
+        "testdevice".to_string()
     }
 }
 
@@ -1213,7 +1225,16 @@ impl Device for TweezerDevice {
                         msg: "Wrapped operation not supported in TweezerDevice".to_string(),
                     }),
                 }
-            }
+            },
+            "PragmaActiveReset" => {
+                if self.allow_reset {
+                    Ok(())
+                } else {
+                    Err(RoqoqoBackendError::GenericError {
+                        msg: "The TweezerDevice instance does not support PragmaActiveReset operations.".to_string(),
+                    })
+                }
+            },
             _ => Err(RoqoqoBackendError::GenericError {
                 msg: "Wrapped operation not supported in TweezerDevice".to_string(),
             }),

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -272,7 +272,7 @@ impl TweezerDevice {
         } else if dev.unwrap_or(false) {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
                     device_name_internal
                 ))
@@ -285,7 +285,7 @@ impl TweezerDevice {
         } else {
             client
                 .get(format!(
-                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/backends/devices/{}",
+                    "https://api.qryddemo.itp3.uni-stuttgart.de/{}/devices/{}",
                     api_version.unwrap_or_else(|| String::from("v1_0")),
                     device_name_internal
                 ))

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -236,7 +236,7 @@ impl TweezerDevice {
         api_version: Option<String>,
     ) -> Result<Self, RoqoqoBackendError> {
         // Preparing variables
-        let device_name_internal = device_name.unwrap_or_else(|| String::from("testdevice"));
+        let device_name_internal = device_name.unwrap_or_else(|| String::from("qryd_emulator"));
         let access_token_internal: String = if mock_port.is_some() {
             "".to_string()
         } else {

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -50,7 +50,7 @@ pub struct TweezerDevice {
     /// Optional seed, for simulation purposes.
     seed: Option<usize>,
     /// Whether to allow PragmaActiveReset operations on the device.
-    allow_reset: bool,
+    pub allow_reset: bool,
 }
 
 /// Tweezers information relative to a Layout

--- a/roqoqo-qryd/tests/integration/api_backend.rs
+++ b/roqoqo-qryd/tests/integration/api_backend.rs
@@ -74,6 +74,8 @@ fn api_backend() {
         }
         circuit += operations::PragmaSetNumberOfMeasurements::new(40, "ro".to_string()); // assert!(api_backend_new.is_ok());
         circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 40, None);
+        circuit += operations::PragmaActiveReset::new(0);
+
         let measurement = ClassicalRegister {
             constant_circuit: None,
             circuits: vec![circuit.clone()],
@@ -204,6 +206,7 @@ fn api_backend() {
         circuit += operations::MeasureQubit::new(0, "ro".to_string(), 0);
         circuit += operations::PragmaSetNumberOfMeasurements::new(10, "ro".to_string());
         circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 40, None);
+        circuit += operations::PragmaActiveReset::new(0);
 
         let measurement = ClassicalRegister {
             constant_circuit: None,

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -45,7 +45,7 @@ fn test_new_tweezer() {
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), Some(1));
     assert_eq!(device.seed(), apidevice.seed());
-    assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
+    assert_eq!(device.qrydbackend(), "testdevice");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
 

--- a/roqoqo-qryd/tests/integration/api_devices.rs
+++ b/roqoqo-qryd/tests/integration/api_devices.rs
@@ -45,7 +45,7 @@ fn test_new_tweezer() {
     let apidevice = QRydAPIDevice::from(&device);
     assert_eq!(device.seed(), Some(1));
     assert_eq!(device.seed(), apidevice.seed());
-    assert_eq!(device.qrydbackend(), "testdevice");
+    assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
     assert_eq!(device.qrydbackend(), apidevice.qrydbackend());
 }
 

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -32,7 +32,7 @@ fn test_new() {
     assert_eq!(device.layout_register.len(), 1);
     assert!(device.layout_register.get("default").is_some());
     assert_eq!(device.seed(), Some(2));
-    assert_eq!(device.qrydbackend(), "testdevice");
+    assert_eq!(device.qrydbackend(), "qryd_tweezer_device");
 
     let device_emp = TweezerDevice::new(None, None, None);
 
@@ -582,6 +582,7 @@ fn test_change_device_shift() {
 fn test_from_api() {
     let mut returned_device_default = TweezerDevice::new(None, None, None);
     returned_device_default.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, None);
+    returned_device_default.device_name = "testdevice".to_string();
     let mut server = Server::new();
     let port = server
         .url()
@@ -605,15 +606,14 @@ fn test_from_api() {
 
     let response = TweezerDevice::from_api(None, None, Some(port.clone()), None, None, None);
     assert!(response.is_ok());
-
     let device = response.unwrap();
     assert_eq!(device, returned_device_default);
+    assert_eq!(device.qrydbackend(), "testdevice".to_string());
 
     let response_new_seed =
         TweezerDevice::from_api(None, None, Some(port.clone()), Some(42), None, None);
     mock.assert();
     assert!(response_new_seed.is_ok());
-
     let device_new_seed = response_new_seed.unwrap();
     assert_eq!(device_new_seed.seed(), Some(42));
 

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -582,7 +582,7 @@ fn test_change_device_shift() {
 fn test_from_api() {
     let mut returned_device_default = TweezerDevice::new(None, None, None);
     returned_device_default.set_tweezer_single_qubit_gate_time("PauliX", 0, 0.23, None);
-    returned_device_default.device_name = "testdevice".to_string();
+    returned_device_default.device_name = "qryd_emulator".to_string();
     let mut server = Server::new();
     let port = server
         .url()
@@ -608,7 +608,7 @@ fn test_from_api() {
     assert!(response.is_ok());
     let device = response.unwrap();
     assert_eq!(device, returned_device_default);
-    assert_eq!(device.qrydbackend(), "testdevice".to_string());
+    assert_eq!(device.qrydbackend(), "qryd_emulator".to_string());
 
     let response_new_seed =
         TweezerDevice::from_api(None, None, Some(port.clone()), Some(42), None, None);
@@ -620,7 +620,7 @@ fn test_from_api() {
     mock.remove();
     mock = server
         .mock("GET", mockito::Matcher::Any)
-        .with_status(400)
+        .with_status(500)
         .create();
 
     let response = TweezerDevice::from_api(None, None, Some(port), None, None, None);
@@ -629,7 +629,7 @@ fn test_from_api() {
     assert_eq!(
         response.unwrap_err(),
         RoqoqoBackendError::NetworkError {
-            msg: format!("Request to server failed with HTTP status code {:?}.", 400),
+            msg: format!("Request to server failed with HTTP status code {:?}.", 500),
         }
     );
 }

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -485,21 +485,15 @@ fn test_change_device() {
         )
         .is_ok());
     assert_eq!(device.current_layout, "Test");
+}
 
-    let pragma_a_r = PragmaActiveReset::new(0);
-    let res = device.change_device("PragmaActiveReset", &serialize(&pragma_a_r).unwrap());
-    assert!(res.is_err());
-    assert_eq!(
-        res.unwrap_err(),
-        RoqoqoBackendError::GenericError {
-            msg: "The TweezerDevice instance does not support PragmaActiveReset operations."
-                .to_string(),
-        }
-    );
+/// Test TweezerDevice allow_reset field
+#[test]
+fn test_allow_reset() {
+    let mut device = TweezerDevice::new(None, None, None);
+    assert!(!device.allow_reset);
     device.set_allow_reset(true);
-    assert!(device
-        .change_device("PragmaActiveReset", &serialize(&pragma_a_r).unwrap())
-        .is_ok());
+    assert!(device.allow_reset);
 }
 
 /// Test TweezerDevice change_device() method with PragmaShiftQubitsTweezers

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -14,7 +14,7 @@ use bincode::serialize;
 use ndarray::Array2;
 use std::collections::HashMap;
 
-use roqoqo::{devices::Device, operations::PragmaActiveReset, RoqoqoBackendError};
+use roqoqo::{devices::Device, RoqoqoBackendError};
 use roqoqo_qryd::{
     phi_theta_relation, PragmaChangeQRydLayout, PragmaShiftQRydQubit, PragmaShiftQubitsTweezers,
     PragmaSwitchDeviceLayout, TweezerDevice,


### PR DESCRIPTION
- Modified `TweezerDevice.from_api()` endpoint, default device name for better `APIBackend` support
- Added support for `PragmaActiveReset` for `APIBackend`, `TweezerDevice`