### PR TITLE
New TweezerDevice.two_qubit_edges() Definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.11.7
+
+* Modified `TweezerDevice.two_qubit_edges()` to consider any two-qubit gate as valid for an edge
+
 # 0.11.6
 
 * Modified `TweezerDevice`'s current layout to be optional

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
@@ -258,7 +258,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -461,9 +461,9 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "inventory"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
+checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
 
 [[package]]
 name = "ipnet"
@@ -488,18 +488,18 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -756,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_derive",
 ]
@@ -897,7 +897,7 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py",
- "syn 2.0.38",
+ "syn 2.0.39",
  "thiserror",
 ]
 
@@ -909,12 +909,12 @@ checksum = "e0361ef299a5691f0ae9ed9bf6eccaa468d61d98635e6aa60730dc46585d2cc6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bincode",
  "mockito",
@@ -1139,7 +1139,7 @@ dependencies = [
  "roqoqo-derive",
  "serde",
  "struqture",
- "syn 2.0.38",
+ "syn 2.0.39",
  "thiserror",
 ]
 
@@ -1151,12 +1151,12 @@ checksum = "0db8bafb647b00998af3cd0e9073a82a60a1f87cfc925b56b3cc94c03cf0cb25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bincode",
  "bitvec",
@@ -1205,7 +1205,7 @@ dependencies = [
  "quote",
  "rand",
  "roqoqo",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1323,7 +1323,7 @@ checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1475,7 +1475,7 @@ dependencies = [
  "serde_json",
  "struqture",
  "struqture-py-macros",
- "syn 2.0.38",
+ "syn 2.0.39",
  "thiserror",
 ]
 
@@ -1488,7 +1488,7 @@ dependencies = [
  "num-complex",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1504,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1565,7 +1565,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1577,7 +1577,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "test-case-core",
 ]
 
@@ -1598,7 +1598,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1644,7 +1644,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1775,9 +1775,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1785,24 +1785,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1822,28 +1822,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
   'numpy',
   'qoqo>=1.6',

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -3166,7 +3166,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-dyn-clone 1.0.14
+dyn-clone 1.0.16
 https://github.com/dtolnay/dyn-clone
 by David Tolnay <dtolnay@gmail.com>
 Clone trait that is object-safe
@@ -10100,7 +10100,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-indexmap 2.0.2
+indexmap 2.1.0
 https://github.com/bluss/indexmap
 by 
 A hash table with consistent order and fast iteration.
@@ -10555,7 +10555,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-inventory 0.3.12
+inventory 0.3.13
 https://github.com/dtolnay/inventory
 by David Tolnay <dtolnay@gmail.com>
 Typed distributed plugin registration
@@ -11447,13 +11447,13 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-js-sys 0.3.64
+js-sys 0.3.65
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bindings for all JS global objects and functions in all JS environments like
 Node.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -11690,7 +11690,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-libc 0.2.149
+libc 0.2.150
 https://github.com/rust-lang/libc
 by The Rust Project Developers
 Raw FFI bindings to platform libraries like libc.
@@ -20119,7 +20119,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.11.5
+qoqo-qryd 0.11.7
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -23862,7 +23862,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.11.5
+roqoqo-qryd 0.11.7
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit
@@ -27108,7 +27108,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-serde_json 1.0.107
+serde_json 1.0.108
 https://github.com/serde-rs/json
 by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 A JSON serialization file format
@@ -29878,7 +29878,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-syn 2.0.38
+syn 2.0.39
 https://github.com/dtolnay/syn
 by David Tolnay <dtolnay@gmail.com>
 Parser for Rust source code
@@ -34136,12 +34136,12 @@ Software.
 
 
 ====================================================
-wasm-bindgen 0.2.87
+wasm-bindgen 0.2.88
 https://rustwasm.github.io/
 by The wasm-bindgen Developers
 Easy support for interacting between JS and Rust.
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -34378,12 +34378,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-backend 0.2.87
+wasm-bindgen-backend 0.2.88
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Backend code generation of the wasm-bindgen tool
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -34620,11 +34620,11 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-futures 0.4.37
+wasm-bindgen-futures 0.4.38
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bridging the gap between Rust Futures and JavaScript Promises
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -34861,12 +34861,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro 0.2.87
+wasm-bindgen-macro 0.2.88
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -35103,12 +35103,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro-support 0.2.87
+wasm-bindgen-macro-support 0.2.88
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -35345,13 +35345,13 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-shared 0.2.87
+wasm-bindgen-shared 0.2.88
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 
@@ -35588,12 +35588,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-web-sys 0.3.64
+web-sys 0.3.65
 https://rustwasm.github.io/wasm-bindgen/web-sys/index.html
 by The wasm-bindgen Developers
 Bindings for all Web APIs, a procedurally generated crate from WebIDL
 
-License: MIT/Apache-2.0
+License: MIT OR Apache-2.0
 ----------------------------------------------------
 LICENSE-APACHE:
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -111,7 +111,7 @@ impl TweezerDeviceWrapper {
     /// This requires a valid QRYD_API_TOKEN. Visit `https://thequantumlaend.de/get-access/` to get one.
     ///
     /// Args
-    ///     device_name (Optional[str]): The name of the device to instantiate. Defaults to "test_device".
+    ///     device_name (Optional[str]): The name of the device to instantiate. Defaults to "qryd_emulator".
     ///     access_token (Optional[str]): An access_token is required to access QRYD hardware and emulators.
     ///                         The access_token can either be given as an argument here
     ///                             or set via the environmental variable `$QRYD_API_TOKEN`.

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -924,6 +924,9 @@ fn test_two_qubit_edges() {
             .extract::<Vec<(usize, usize)>>()
             .unwrap();
         assert_eq!(new_edges_mut.len(), 3);
+        assert!(new_edges_mut.contains(&(0, 1)));
+        assert!(new_edges_mut.contains(&(1, 2)));
+        assert!(new_edges_mut.contains(&(0, 2)));
     });
 }
 

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -869,11 +869,16 @@ fn test_to_from_bincode() {
 /// Test two_qubit_edges function of TweezerDeviceWrapper and TweezerMutableDeviceWrapper
 #[test]
 fn test_two_qubit_edges() {
+    // Setup fake preconfigured device
+    let mut ext = TweezerDevice::new(None, None, None);
+    ext.add_layout("default").unwrap();
+    ext.current_layout = Some("default".to_string());
+    let fake_api_device = TweezerDeviceWrapper { internal: ext };
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<TweezerDeviceWrapper>();
+        let fake_api_pypyany = fake_api_device.into_py(py);
         let device_type_mut = py.get_type::<TweezerMutableDeviceWrapper>();
-        let device = device_type.call0().unwrap();
+        let device = fake_api_pypyany.as_ref(py);
         let device_mut = device_type_mut.call0().unwrap();
 
         device_mut.call_method1("add_layout", ("default",)).unwrap();
@@ -897,14 +902,11 @@ fn test_two_qubit_edges() {
         device_mut
             .call_method1(
                 "set_tweezer_two_qubit_gate_time",
-                ("PhaseShiftedControlledPhase", 1, 2, 0.13),
+                ("PhaseShiftedControlledZ", 1, 2, 0.13),
             )
             .unwrap();
         device_mut
-            .call_method1(
-                "set_tweezer_two_qubit_gate_time",
-                ("PhaseShiftedControlledPhase", 0, 2, 0.13),
-            )
+            .call_method1("set_tweezer_two_qubit_gate_time", ("CNOT", 0, 2, 0.13))
             .unwrap();
         device_mut
             .call_method1("add_qubit_tweezer_mapping", (0, 0))

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -1181,15 +1181,25 @@ impl Device for TweezerDevice {
     }
 
     fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
+        let tw_two_qubit_gate_times = &self
+            .get_current_layout_info()
+            .unwrap()
+            .tweezer_two_qubit_gate_times;
         if let Some(map) = &self.qubit_to_tweezer {
             let mut edges: Vec<(usize, usize)> = Vec::new();
             for qbt0 in map.keys() {
                 for qbt1 in map.keys() {
-                    if self
-                        .two_qubit_gate_time("PhaseShiftedControlledPhase", qbt0, qbt1)
-                        .is_some()
-                    {
-                        edges.push((*qbt0, *qbt1));
+                    let mapped_qbt0 = self.get_tweezer_from_qubit(qbt0).ok();
+                    let mapped_qbt1 = self.get_tweezer_from_qubit(qbt1).ok();
+                    for gate in tw_two_qubit_gate_times.keys() {
+                        if mapped_qbt0.is_some()
+                            && mapped_qbt1.is_some()
+                            && tw_two_qubit_gate_times[gate]
+                                .get(&(mapped_qbt0.unwrap(), mapped_qbt1.unwrap()))
+                                .is_some()
+                        {
+                            edges.push((*qbt0, *qbt1));
+                        }
                     }
                 }
             }

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -1183,7 +1183,7 @@ impl Device for TweezerDevice {
     fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
         let tw_two_qubit_gate_times = &self
             .get_current_layout_info()
-            .unwrap()
+            .expect("Tried to access current layout info but no current layout is set.")
             .tweezer_two_qubit_gate_times;
         if let Some(map) = &self.qubit_to_tweezer {
             let mut edges: Vec<(usize, usize)> = Vec::new();


### PR DESCRIPTION
- Modified `TweezerDevice.two_qubit_edges()` to consider any two-qubit gate as valid for an edge