### PR TITLE
TweezerDevice Additions and Support for SimulatorBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Tracks qoqo-qryd changes after 0.5
 
-# Unreleased - 0.13.0
+# 0.13.0
+
+* Added `TweezerDevice.get_qubit_to_tweezer_mapping`
+* Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
+
 
 # 0.12.2
 
@@ -10,12 +14,12 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.12.1
 
-* Updated to qoqo 1.9
+* Updated to Qoqo 1.9
 * Fixed `TweezerDevice.number_qubits()` incorrect implementation
 
 # 0.12.0
 
-* Updated to qoqo 1.8
+* Updated to Qoqo 1.8
 * Updated to Pyo3 0.20
 
 # 0.11.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# Unreleased - 0.13.0
+
 # 0.12.2
 
 * Added `TweezerDevice.number_tweezer_positions()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Tracks qoqo-qryd changes after 0.5
 * Added `number_qubits` parameter to `SimulatorBackend`
 * Modified `TweezerDevice.number_qubits()` back to index-based implementation
 * Dropped `FirstDevice` support for `SimulatorBackend`
+* Updated to `mockito` 1.2
+* Updated the MSRV to 1.68
 
 # 0.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Tracks qoqo-qryd changes after 0.5
 * Added `layout_name` parameter to `TweezerDevice.number_tweezer_positions()`
 * Added `TweezerDevice` support for `SimulatorBackend`
 * Added `number_qubits` parameter to `SimulatorBackend`
+* Modified `TweezerDevice.number_qubits()` back to index-based implementation
+* Dropped `FirstDevice` support for `FirstDevice`
 
 # 0.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Tracks qoqo-qryd changes after 0.5
 * Added `TweezerDevice.get_qubit_to_tweezer_mapping`
 * Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
 
-
 # 0.12.2
 
 * Added `TweezerDevice.number_tweezer_positions()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Tracks qoqo-qryd changes after 0.5
 
 * Added `TweezerDevice.get_qubit_to_tweezer_mapping()`
 * Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
+* Added `layout_name` parameter to `TweezerDevice.number_tweezer_positions()`
 * Added `TweezerDevice` support for `SimulatorBackend`
 * Added `number_qubits` parameter to `SimulatorBackend`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Tracks qoqo-qryd changes after 0.5
 * Added `TweezerDevice` support for `SimulatorBackend`
 * Added `number_qubits` parameter to `SimulatorBackend`
 * Modified `TweezerDevice.number_qubits()` back to index-based implementation
-* Dropped `FirstDevice` support for `FirstDevice`
+* Dropped `FirstDevice` support for `SimulatorBackend`
 
 # 0.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.13.0
 
-* Added `TweezerDevice.get_qubit_to_tweezer_mapping`
+* Added `TweezerDevice.get_qubit_to_tweezer_mapping()`
 * Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
 * Added `TweezerDevice` support for `SimulatorBackend`
 * Added `number_qubits` parameter to `SimulatorBackend`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Tracks qoqo-qryd changes after 0.5
 
 * Added `TweezerDevice.get_qubit_to_tweezer_mapping`
 * Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
+* Added `TweezerDevice` support for `SimulatorBackend`
+* Added `number_qubits` parameter to `SimulatorBackend`
 
 # 0.12.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -451,9 +451,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inventory"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "ipnet"
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -1044,9 +1044,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64",
  "bytes",
@@ -1070,6 +1070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -1284,18 +1285,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1315,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1410,7 +1411,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b3b736950a60ff795d13e8e89d75fde0bd9510ea420f06c0649791f6fe3194"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "ndarray",
  "num-complex",
  "qoqo_calculator",
@@ -1478,6 +1479,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
@@ -1815,9 +1822,9 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "wide"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31891d644eba1789fb6715f27fbc322e4bdf2ecdc412ede1993246159271613"
+checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "bytes"
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,9 +1590,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "bincode",
  "mockito",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "bincode",
  "bitvec",

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.13.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.56"
+rust-version = "1.68"
 categories = ["science", "simulation"]
 readme = "README.md"
 homepage = "https://github.com/HQSquantumsimulations/qoqo_qryd"
@@ -51,7 +51,7 @@ roqoqo-qryd = { version = "0.13", path = "../roqoqo-qryd", default-features = fa
 
 [dev-dependencies]
 test-case = "3.0"
-mockito = { version = "1.1", default-features = false }
+mockito = { version = "1.2", default-features = false }
 serde_json = "1.0"
 
 [build-dependencies]

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -41,10 +41,10 @@ numpy = "0.20"
 
 qoqo_calculator = { version = "1.1" }
 qoqo_calculator_pyo3 = { version = "1.1", default-features = false }
-qoqo = { version="1.9", default-features = false }
-roqoqo = { version="1.9", features = ["serialize"] }
+qoqo = { version = "1.9", default-features = false }
+roqoqo = { version = "1.9", features = ["serialize"] }
 
-roqoqo-qryd = { version = "0.12", path = "../roqoqo-qryd", default-features = false, features = [
+roqoqo-qryd = { version = "0.13", path = "../roqoqo-qryd", default-features = false, features = [
     "web-api",
 ] }
 

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,14 +1,12 @@
 [project]
 name = "qoqo_qryd"
-version = "0.12.2"
-dependencies = [
-  'numpy',
-  'qoqo>=1.9',
-  'qoqo_calculator_pyo3>=1.1',
+version = "0.13.0"
+dependencies = ['numpy', 'qoqo>=1.9', 'qoqo_calculator_pyo3>=1.1']
+license = { text = "Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause" }
+maintainers = [
+  { name = "HQS Quantum Simulations GmbH", email = "info@quantumsimulations.de" },
 ]
-license = {text="Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause"}
-maintainers = [{name = "HQS Quantum Simulations GmbH", email = "info@quantumsimulations.de"}]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 docs = [

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -19362,7 +19362,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.12.2
+qoqo-qryd 0.13.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -23105,7 +23105,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.12.2
+roqoqo-qryd 0.13.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -516,11 +516,15 @@ impl TweezerDeviceWrapper {
 
     /// Returns the number of total tweezer positions in the device.
     ///
+    /// Arguments:
+    ///     layout_name (Optional[str]): The name of the layout to reference. Defaults to the current layout.
+    ///
     /// Returns:
     ///     int: The number of tweezer positions in the device.
-    pub fn number_tweezer_positions(&self) -> PyResult<usize> {
+    #[pyo3(text_signature = "(layout_name, /)")]
+    pub fn number_tweezer_positions(&self, layout_name: Option<String>) -> PyResult<usize> {
         self.internal
-            .number_tweezer_positions()
+            .number_tweezer_positions(layout_name)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
@@ -1038,11 +1042,15 @@ impl TweezerMutableDeviceWrapper {
 
     /// Returns the number of total tweezer positions in the device.
     ///
+    /// Arguments:
+    ///     layout_name (Optional[str]): The name of the layout to reference. Defaults to the current layout.
+    ///
     /// Returns:
     ///     int: The number of tweezer positions in the device.
-    pub fn number_tweezer_positions(&self) -> PyResult<usize> {
+    #[pyo3(text_signature = "(layout_name, /)")]
+    pub fn number_tweezer_positions(&self, layout_name: Option<String>) -> PyResult<usize> {
         self.internal
-            .number_tweezer_positions()
+            .number_tweezer_positions(layout_name)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -158,13 +158,14 @@ impl TweezerDeviceWrapper {
     ///
     /// Args:
     ///     layout_number (str): The number index of the new layout
+    ///     with_trivial_map (bool): Whether the qubit -> tweezer mapping should be trivially populated. Defaults to true.
     ///
     /// Raises:
     ///     PyValueError
-    #[pyo3(text_signature = "(name, /)")]
-    pub fn switch_layout(&mut self, name: &str) -> PyResult<()> {
+    #[pyo3(text_signature = "(name, with_trivial_map, /)")]
+    pub fn switch_layout(&mut self, name: &str, with_trivial_map: Option<bool>) -> PyResult<()> {
         self.internal
-            .switch_layout(name)
+            .switch_layout(name, with_trivial_map)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
@@ -200,6 +201,20 @@ impl TweezerDeviceWrapper {
                 Ok(mapping) => Ok(mapping.into_py_dict(py).into()),
                 Err(err) => Err(PyValueError::new_err(format!("{:}", err))),
             }
+        })
+    }
+
+    /// Get the qubit -> tweezer mapping of the device.
+    ///
+    /// Returns:
+    ///     dict[int, int]: The qubit -> tweezer mapping.
+    ///     None: The mapping is empty.
+    pub fn get_qubit_to_tweezer_mapping(&self) -> Option<PyObject> {
+        Python::with_gil(|py| -> Option<PyObject> {
+            self.internal
+                .qubit_to_tweezer
+                .as_ref()
+                .map(|mapping| mapping.into_py_dict(py).into())
         })
     }
 
@@ -481,7 +496,7 @@ impl TweezerDeviceWrapper {
             .map_err(|_| PyValueError::new_err("Input cannot be deserialized to TweezerDevice"))?;
         if let Some(layout) = &internal.default_layout {
             let _ = internal
-                .switch_layout(&layout.to_string())
+                .switch_layout(&layout.to_string(), None)
                 .map_err(|err| PyValueError::new_err(format!("{:}", err)));
         }
         Ok(TweezerDeviceWrapper { internal })
@@ -661,13 +676,14 @@ impl TweezerMutableDeviceWrapper {
     ///
     /// Args:
     ///     layout_number (str): The number index of the new layout
+    ///     with_trivial_map (bool): Whether the qubit -> tweezer mapping should be trivially populated. Defaults to true.
     ///
     /// Raises:
     ///     PyValueError
-    #[pyo3(text_signature = "(name, /)")]
-    pub fn switch_layout(&mut self, name: &str) -> PyResult<()> {
+    #[pyo3(text_signature = "(name, with_trivial_map, /)")]
+    pub fn switch_layout(&mut self, name: &str, with_trivial_map: Option<bool>) -> PyResult<()> {
         self.internal
-            .switch_layout(name)
+            .switch_layout(name, with_trivial_map)
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
@@ -703,6 +719,20 @@ impl TweezerMutableDeviceWrapper {
                 Ok(mapping) => Ok(mapping.into_py_dict(py).into()),
                 Err(err) => Err(PyValueError::new_err(format!("{:}", err))),
             }
+        })
+    }
+
+    /// Get the qubit -> tweezer mapping of the device.
+    ///
+    /// Returns:
+    ///     dict[int, int]: The qubit -> tweezer mapping.
+    ///     None: The mapping is empty.
+    pub fn get_qubit_to_tweezer_mapping(&self) -> Option<PyObject> {
+        Python::with_gil(|py| -> Option<PyObject> {
+            self.internal
+                .qubit_to_tweezer
+                .as_ref()
+                .map(|mapping| mapping.into_py_dict(py).into())
         })
     }
 

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -154,10 +154,14 @@ impl TweezerDeviceWrapper {
             .as_str()
     }
 
-    /// Switch to a different pre-defined layout.
+    /// Switch to a different pre-defined Layout.
+    ///
+    /// It is updated only if the given Layout name is present in the device's
+    /// Layout register. If the qubit -> tweezer mapping is empty, it is
+    /// trivially populated by default.
     ///
     /// Args:
-    ///     layout_number (str): The number index of the new layout
+    ///     layout_number (str): The number index of the new Layout.
     ///     with_trivial_map (bool): Whether the qubit -> tweezer mapping should be trivially populated. Defaults to true.
     ///
     /// Raises:
@@ -672,10 +676,14 @@ impl TweezerMutableDeviceWrapper {
             .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
-    /// Switch to a different pre-defined layout.
+    /// Switch to a different pre-defined Layout.
+    ///
+    /// It is updated only if the given Layout name is present in the device's
+    /// Layout register. If the qubit -> tweezer mapping is empty, it is
+    /// trivially populated by default.
     ///
     /// Args:
-    ///     layout_number (str): The number index of the new layout
+    ///     layout_number (str): The number index of the new Layout.
     ///     with_trivial_map (bool): Whether the qubit -> tweezer mapping should be trivially populated. Defaults to true.
     ///
     /// Raises:

--- a/qoqo-qryd/tests/integration/simulator_backend.rs
+++ b/qoqo-qryd/tests/integration/simulator_backend.rs
@@ -518,9 +518,9 @@ fn test_to_from_json() {
     });
 }
 
-/// Test convert_to_device()
+/// Test convert_to_backend()
 #[test]
-fn test_convert_to_device() {
+fn test_convert_to_backend() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
         let device_type = py.get_type::<TweezerMutableDeviceWrapper>();

--- a/qoqo-qryd/tests/integration/simulator_backend.rs
+++ b/qoqo-qryd/tests/integration/simulator_backend.rs
@@ -12,67 +12,20 @@
 
 //! Integration test for public API of Basis rotation measurement
 
-use ndarray::array;
-use numpy::ToPyArray;
 use pyo3::prelude::*;
 use pyo3::Python;
 use qoqo::measurements::{ClassicalRegisterWrapper, PauliZProductWrapper};
 use qoqo::CircuitWrapper;
-use qoqo_qryd::qryd_devices::FirstDeviceWrapper;
 use qoqo_qryd::simulator_backend::{convert_into_backend, SimulatorBackendWrapper};
 use qoqo_qryd::{TweezerDeviceWrapper, TweezerMutableDeviceWrapper};
 use roqoqo::measurements::{ClassicalRegister, PauliZProduct, PauliZProductInput};
 use roqoqo::operations;
 use roqoqo::Circuit;
-use roqoqo_qryd::SimulatorDevice;
-use roqoqo_qryd::{FirstDevice, SimulatorBackend};
+use roqoqo_qryd::SimulatorBackend;
+use roqoqo_qryd::TweezerDevice;
 
 #[test]
 fn test_creating_backend() {
-    pyo3::prepare_freethreaded_python();
-    Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
-        let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
-            .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
-            .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
-        let backend_type = py.get_type::<SimulatorBackendWrapper>();
-        let _backend = backend_type
-            .call1((device,))
-            .unwrap()
-            .downcast::<PyCell<SimulatorBackendWrapper>>()
-            .unwrap();
-    });
-
-    Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
-        let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
-            .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
-            .unwrap();
-        let backend_type = py.get_type::<SimulatorBackendWrapper>();
-        let _backend = backend_type
-            .call1((device,))
-            .unwrap()
-            .downcast::<PyCell<SimulatorBackendWrapper>>()
-            .unwrap();
-    });
-
     Python::with_gil(|py| {
         let device_type = py.get_type::<TweezerDeviceWrapper>();
         let device = device_type
@@ -111,19 +64,6 @@ fn test_running_circuit() {
     circuit += operations::PragmaRepeatedMeasurement::new("readout".to_string(), 100, None);
     let circuit_wrapper = CircuitWrapper { internal: circuit };
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
-        let device_fd = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
-            .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
-            .unwrap();
-        let _ = device_fd.call_method1("switch_layout", (0,)).unwrap();
         let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device_tw = device_type
             .call0()
@@ -146,19 +86,11 @@ fn test_running_circuit() {
         device_tw.call_method1("switch_layout", ("test",)).unwrap();
 
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
-        let backend_fd = backend_type
-            .call1((device_fd,))
-            .unwrap()
-            .downcast::<PyCell<SimulatorBackendWrapper>>()
-            .unwrap();
         let backend_tw = backend_type
             .call1((device_tw,))
             .unwrap()
             .downcast::<PyCell<SimulatorBackendWrapper>>()
             .unwrap();
-        assert!(backend_fd
-            .call_method1("run_circuit", (circuit_wrapper.clone(),))
-            .is_ok());
         assert!(backend_tw
             .call_method1("run_circuit", (circuit_wrapper,))
             .is_ok());
@@ -169,19 +101,26 @@ fn test_running_circuit() {
 fn test_running_circuit_error() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -211,19 +150,26 @@ fn test_running_measurement_registers() {
         internal: cr_measurement,
     };
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -240,19 +186,26 @@ fn test_running_measurement_registers() {
 fn test_running_measurement_registers_error_1() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -275,19 +228,26 @@ fn test_running_measurement_registers_some() {
         internal: cr_measurement,
     };
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -323,19 +283,26 @@ fn test_running_measurement_registers_all_registers() {
         internal: cr_measurement,
     };
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -373,19 +340,26 @@ fn test_running_measurement() {
         internal: cr_measurement,
     };
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
-        let _ = device.call_method1("switch_layout", (0,)).unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -403,18 +377,26 @@ fn test_running_measurement() {
 fn test_copy_deepcopy() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -438,18 +420,26 @@ fn test_copy_deepcopy() {
 fn test_to_from_bincode() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -481,18 +471,26 @@ fn test_to_from_bincode() {
 fn test_to_from_json() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -525,18 +523,26 @@ fn test_to_from_json() {
 fn test_convert_to_device() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -545,19 +551,21 @@ fn test_convert_to_device() {
             .unwrap();
 
         let converted = convert_into_backend(backend).unwrap();
-        let rust_dev: SimulatorDevice = FirstDevice::new(
-            2,
-            2,
-            &[1, 1],
-            1.0,
-            array![[0.0, 1.0,], [0.0, 1.0]],
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap()
-        .into();
+        let mut rust_dev = TweezerDevice::new(None, None, None);
+        rust_dev.add_layout("test").unwrap();
+        rust_dev
+            .set_tweezer_single_qubit_gate_time("RotateX", 0, 1.0, Some("test".to_string()))
+            .unwrap();
+        rust_dev
+            .set_tweezer_two_qubit_gate_time(
+                "PhaseShiftedControlledZ",
+                0,
+                1,
+                1.0,
+                Some("test".to_string()),
+            )
+            .unwrap();
+        rust_dev.switch_layout("test", None).unwrap();
         let rust_backend = SimulatorBackend::new(rust_dev, None);
         assert_eq!(converted, rust_backend);
         assert!(convert_into_backend(device).is_err());
@@ -568,19 +576,26 @@ fn test_convert_to_device() {
 fn test_pyo3_new_change_layout() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let layout = array![[0.0, 1.0], [0.0, 1.0]];
-        let device_type = py.get_type::<FirstDeviceWrapper>();
+        let device_type = py.get_type::<TweezerMutableDeviceWrapper>();
         let device = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                1.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
+        device.call_method1("add_layout", ("test",)).unwrap();
+        device
+            .call_method1(
+                "set_tweezer_single_qubit_gate_time",
+                ("RotateX", 0, 1.0, "test"),
+            )
+            .unwrap();
+        device
+            .call_method1(
+                "set_tweezer_two_qubit_gate_time",
+                ("PhaseShiftedControlledZ", 0, 1, 1.0, "test"),
+            )
+            .unwrap();
+        device.call_method1("switch_layout", ("test",)).unwrap();
         let backend_type = py.get_type::<SimulatorBackendWrapper>();
         let backend = backend_type
             .call1((device,))
@@ -590,15 +605,9 @@ fn test_pyo3_new_change_layout() {
 
         let pragma_wrapper = backend.extract::<SimulatorBackendWrapper>().unwrap();
         let device_diff = device_type
-            .call1((
-                2,
-                2,
-                vec![1, 1],
-                2.0,
-                array![[0.0, 1.0], [0.0, 1.0]].to_pyarray(py),
-            ))
+            .call0()
             .unwrap()
-            .downcast::<PyCell<FirstDeviceWrapper>>()
+            .downcast::<PyCell<TweezerMutableDeviceWrapper>>()
             .unwrap();
         let new_op_diff = backend_type
             .call1((device_diff,))
@@ -610,19 +619,5 @@ fn test_pyo3_new_change_layout() {
         assert!(helper_ne);
         let helper_eq: bool = pragma_wrapper == pragma_wrapper.clone();
         assert!(helper_eq);
-
-        let check_str = format!("{:?}", pragma_wrapper);
-        let check_1: &str = check_str.split("qubit_positions").collect::<Vec<&str>>()[0];
-        let check_2: &str = check_str.split("qubit_positions").collect::<Vec<&str>>()[1]
-            .split(")}")
-            .collect::<Vec<&str>>()[1];
-        let comp_str = format!("SimulatorBackendWrapper {{ internal: SimulatorBackend {{ device: QRydDevice(FirstDevice(FirstDevice {{ number_rows: 2, number_columns: 2, qubit_positions: {{0: (0, 0), 1: (1, 0)}}, row_distance: 1.0, layout_register: {{0: {:?}}}, current_layout: 0, cutoff: 1.0, controlled_z_phase_relation: \"DefaultRelation\", controlled_phase_phase_relation: \"DefaultRelation\", allow_ccz_gate: true, allow_ccp_gate: false }})), number_qubits: 2 }} }}", layout);
-        let comp_1: &str = comp_str.split("qubit_positions").collect::<Vec<&str>>()[0];
-        let comp_2: &str = comp_str.split("qubit_positions").collect::<Vec<&str>>()[1]
-            .split(")}")
-            .collect::<Vec<&str>>()[1];
-
-        assert_eq!(comp_1, check_1);
-        assert_eq!(comp_2, check_2);
     })
 }

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -708,8 +708,21 @@ fn test_number_tweezer_positions() {
         let device_mut = device_type_mut.call0().unwrap();
 
         device_mut.call_method1("add_layout", ("default",)).unwrap();
+        device_mut.call_method1("add_layout", ("empty",)).unwrap();
+
+        assert_eq!(
+            device_mut
+                .call_method1("number_tweezer_positions", ("empty",))
+                .unwrap()
+                .extract::<usize>()
+                .unwrap(),
+            0
+        );
 
         assert!(device_mut.call_method0("number_tweezer_positions").is_err());
+        assert!(device_mut
+            .call_method1("number_tweezer_positions", ("error",))
+            .is_err());
 
         device_mut
             .call_method1("switch_layout", ("default",))

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -38,15 +38,15 @@ bitvec = { version = "1.0", optional = true }
 hex = { version = "0.4", optional = true }
 itertools = "0.11"
 
-roqoqo = { version="1.9", features = ["serialize"] }
-roqoqo-derive = { version="1.9" }
-roqoqo-quest = { version="0.11", default-features = false, optional = true }
+roqoqo = { version = "1.9", features = ["serialize"] }
+roqoqo-derive = { version = "1.9" }
+roqoqo-quest = { version = "0.11", default-features = false, optional = true }
 qoqo_calculator = { version = "1.1" }
 
 [dev-dependencies]
 test-case = "3.0"
 serde_test = { version = "1.0" }
-roqoqo-test = { version="1.8" }
+roqoqo-test = { version = "1.9" }
 mockito = { version = "1.1", default-features = false }
 
 [features]

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.13.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.56"
+rust-version = "1.68"
 categories = ["science", "simulation"]
 readme = "../README.md"
 repository = "https://github.com/HQSquantumsimulations/qoqo_qryd"
@@ -47,7 +47,7 @@ qoqo_calculator = { version = "1.1" }
 test-case = "3.0"
 serde_test = { version = "1.0" }
 roqoqo-test = { version = "1.9" }
-mockito = { version = "1.1", default-features = false }
+mockito = { version = "1.2", default-features = false }
 
 [features]
 default = ["simulator", "web-api"]

--- a/roqoqo-qryd/src/simulator_backend.rs
+++ b/roqoqo-qryd/src/simulator_backend.rs
@@ -29,6 +29,27 @@ pub enum SimulatorDevice {
 }
 
 impl Device for SimulatorDevice {
+    fn multi_qubit_gate_names(&self) -> Vec<String> {
+        match self {
+            SimulatorDevice::QRydDevice(device) => device.multi_qubit_gate_names(),
+            SimulatorDevice::TweezerDevice(device) => device.multi_qubit_gate_names(),
+        }
+    }
+
+    fn single_qubit_gate_names(&self) -> Vec<String> {
+        match self {
+            SimulatorDevice::QRydDevice(device) => device.single_qubit_gate_names(),
+            SimulatorDevice::TweezerDevice(device) => device.single_qubit_gate_names(),
+        }
+    }
+
+    fn two_qubit_gate_names(&self) -> Vec<String> {
+        match self {
+            SimulatorDevice::QRydDevice(device) => device.two_qubit_gate_names(),
+            SimulatorDevice::TweezerDevice(device) => device.two_qubit_gate_names(),
+        }
+    }
+
     fn single_qubit_gate_time(&self, hqslang: &str, qubit: &usize) -> Option<f64> {
         match self {
             SimulatorDevice::QRydDevice(x) => x.single_qubit_gate_time(hqslang, qubit),
@@ -85,6 +106,17 @@ impl Device for SimulatorDevice {
         match self {
             SimulatorDevice::QRydDevice(x) => x.two_qubit_edges(),
             SimulatorDevice::TweezerDevice(x) => x.two_qubit_edges(),
+        }
+    }
+
+    fn change_device(
+        &mut self,
+        hqslang: &str,
+        operation: &[u8],
+    ) -> Result<(), roqoqo::prelude::RoqoqoBackendError> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.change_device(hqslang, operation),
+            SimulatorDevice::TweezerDevice(x) => x.change_device(hqslang, operation),
         }
     }
 

--- a/roqoqo-qryd/src/simulator_backend.rs
+++ b/roqoqo-qryd/src/simulator_backend.rs
@@ -11,10 +11,102 @@
 // limitations under the License.
 
 use crate::qryd_devices::QRydDevice;
+use crate::FirstDevice;
+use crate::TweezerDevice;
 use roqoqo::backends::EvaluatingBackend;
 use roqoqo::backends::RegisterResult;
 use roqoqo::devices::Device;
 use roqoqo::operations::*;
+
+/// Collection of all QRyd devices
+///
+#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub enum SimulatorDevice {
+    /// Old Qryd device
+    QRydDevice(QRydDevice),
+    /// New TweezerDevice
+    TweezerDevice(TweezerDevice),
+}
+
+impl Device for SimulatorDevice {
+    fn single_qubit_gate_time(&self, hqslang: &str, qubit: &usize) -> Option<f64> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.single_qubit_gate_time(hqslang, qubit),
+            SimulatorDevice::TweezerDevice(x) => x.single_qubit_gate_time(hqslang, qubit),
+        }
+    }
+
+    fn two_qubit_gate_time(&self, hqslang: &str, control: &usize, target: &usize) -> Option<f64> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.two_qubit_gate_time(hqslang, control, target),
+            SimulatorDevice::TweezerDevice(x) => x.two_qubit_gate_time(hqslang, control, target),
+        }
+    }
+
+    fn three_qubit_gate_time(
+        &self,
+        hqslang: &str,
+        control_0: &usize,
+        control_1: &usize,
+        target: &usize,
+    ) -> Option<f64> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => {
+                x.three_qubit_gate_time(hqslang, control_0, control_1, target)
+            }
+            SimulatorDevice::TweezerDevice(x) => {
+                x.three_qubit_gate_time(hqslang, control_0, control_1, target)
+            }
+        }
+    }
+
+    fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.multi_qubit_gate_time(hqslang, qubits),
+            SimulatorDevice::TweezerDevice(x) => x.multi_qubit_gate_time(hqslang, qubits),
+        }
+    }
+
+    fn qubit_decoherence_rates(&self, qubit: &usize) -> Option<ndarray::prelude::Array2<f64>> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.qubit_decoherence_rates(qubit),
+            SimulatorDevice::TweezerDevice(x) => x.qubit_decoherence_rates(qubit),
+        }
+    }
+
+    fn number_qubits(&self) -> usize {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.number_qubits(),
+            SimulatorDevice::TweezerDevice(x) => x.number_qubits(),
+        }
+    }
+
+    fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.two_qubit_edges(),
+            SimulatorDevice::TweezerDevice(x) => x.two_qubit_edges(),
+        }
+    }
+
+    fn to_generic_device(&self) -> roqoqo::devices::GenericDevice {
+        match self {
+            SimulatorDevice::QRydDevice(x) => x.to_generic_device(),
+            SimulatorDevice::TweezerDevice(x) => x.to_generic_device(),
+        }
+    }
+}
+
+impl From<FirstDevice> for SimulatorDevice {
+    fn from(input: FirstDevice) -> Self {
+        Self::QRydDevice(QRydDevice::FirstDevice(input))
+    }
+}
+
+impl From<TweezerDevice> for SimulatorDevice {
+    fn from(input: TweezerDevice) -> Self {
+        Self::TweezerDevice(input)
+    }
+}
 
 /// QRyd simulator backend
 ///
@@ -27,12 +119,14 @@ use roqoqo::operations::*;
 ///
 ///
 /// The simulator backend implements the [roqoqo::backends::EvaluatingBackend] trait
-/// and is compatible with  running single circuits, running and evaluating measurements
+/// and is compatible with running single circuits, running and evaluating measurements
 /// and running QuantumPrograms on simulated QRyd devices.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SimulatorBackend {
     /// Device representing the model of a QRyd device.
-    pub device: QRydDevice,
+    pub device: SimulatorDevice,
+    /// The number of qubits allocated by the simulator.
+    pub number_qubits: usize,
 }
 
 impl SimulatorBackend {
@@ -41,8 +135,12 @@ impl SimulatorBackend {
     /// # Arguments
     ///
     /// `device` - The QRyd device used for the simulation.
-    pub fn new(device: QRydDevice) -> Self {
-        Self { device }
+    /// `number_qubits` - The number of qubits the simulator should use. Defaults to `device.number_qubits()`.
+    pub fn new(device: SimulatorDevice, number_qubits: Option<usize>) -> Self {
+        Self {
+            device: device.clone(),
+            number_qubits: number_qubits.unwrap_or(device.number_qubits()),
+        }
     }
 }
 
@@ -53,7 +151,7 @@ impl EvaluatingBackend for SimulatorBackend {
     ) -> RegisterResult {
         let mut tmp_device: Option<Box<dyn Device>> = Some(Box::new(self.device.clone()));
 
-        let quest_backend = roqoqo_quest::Backend::new(self.device.number_qubits());
+        let quest_backend = roqoqo_quest::Backend::new(self.number_qubits);
 
         quest_backend.run_circuit_iterator_with_device(circuit, &mut tmp_device)
     }

--- a/roqoqo-qryd/src/simulator_backend.rs
+++ b/roqoqo-qryd/src/simulator_backend.rs
@@ -10,142 +10,19 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::qryd_devices::QRydDevice;
-use crate::FirstDevice;
-use crate::TweezerDevice;
 use roqoqo::backends::EvaluatingBackend;
 use roqoqo::backends::RegisterResult;
 use roqoqo::devices::Device;
 use roqoqo::operations::*;
 
-/// Collection of all QRyd devices
-///
-#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub enum SimulatorDevice {
-    /// Old Qryd device
-    QRydDevice(QRydDevice),
-    /// New TweezerDevice
-    TweezerDevice(TweezerDevice),
-}
-
-impl Device for SimulatorDevice {
-    fn multi_qubit_gate_names(&self) -> Vec<String> {
-        match self {
-            SimulatorDevice::QRydDevice(device) => device.multi_qubit_gate_names(),
-            SimulatorDevice::TweezerDevice(device) => device.multi_qubit_gate_names(),
-        }
-    }
-
-    fn single_qubit_gate_names(&self) -> Vec<String> {
-        match self {
-            SimulatorDevice::QRydDevice(device) => device.single_qubit_gate_names(),
-            SimulatorDevice::TweezerDevice(device) => device.single_qubit_gate_names(),
-        }
-    }
-
-    fn two_qubit_gate_names(&self) -> Vec<String> {
-        match self {
-            SimulatorDevice::QRydDevice(device) => device.two_qubit_gate_names(),
-            SimulatorDevice::TweezerDevice(device) => device.two_qubit_gate_names(),
-        }
-    }
-
-    fn single_qubit_gate_time(&self, hqslang: &str, qubit: &usize) -> Option<f64> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.single_qubit_gate_time(hqslang, qubit),
-            SimulatorDevice::TweezerDevice(x) => x.single_qubit_gate_time(hqslang, qubit),
-        }
-    }
-
-    fn two_qubit_gate_time(&self, hqslang: &str, control: &usize, target: &usize) -> Option<f64> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.two_qubit_gate_time(hqslang, control, target),
-            SimulatorDevice::TweezerDevice(x) => x.two_qubit_gate_time(hqslang, control, target),
-        }
-    }
-
-    fn three_qubit_gate_time(
-        &self,
-        hqslang: &str,
-        control_0: &usize,
-        control_1: &usize,
-        target: &usize,
-    ) -> Option<f64> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => {
-                x.three_qubit_gate_time(hqslang, control_0, control_1, target)
-            }
-            SimulatorDevice::TweezerDevice(x) => {
-                x.three_qubit_gate_time(hqslang, control_0, control_1, target)
-            }
-        }
-    }
-
-    fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.multi_qubit_gate_time(hqslang, qubits),
-            SimulatorDevice::TweezerDevice(x) => x.multi_qubit_gate_time(hqslang, qubits),
-        }
-    }
-
-    fn qubit_decoherence_rates(&self, qubit: &usize) -> Option<ndarray::prelude::Array2<f64>> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.qubit_decoherence_rates(qubit),
-            SimulatorDevice::TweezerDevice(x) => x.qubit_decoherence_rates(qubit),
-        }
-    }
-
-    fn number_qubits(&self) -> usize {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.number_qubits(),
-            SimulatorDevice::TweezerDevice(x) => x.number_qubits(),
-        }
-    }
-
-    fn two_qubit_edges(&self) -> Vec<(usize, usize)> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.two_qubit_edges(),
-            SimulatorDevice::TweezerDevice(x) => x.two_qubit_edges(),
-        }
-    }
-
-    fn change_device(
-        &mut self,
-        hqslang: &str,
-        operation: &[u8],
-    ) -> Result<(), roqoqo::prelude::RoqoqoBackendError> {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.change_device(hqslang, operation),
-            SimulatorDevice::TweezerDevice(x) => x.change_device(hqslang, operation),
-        }
-    }
-
-    fn to_generic_device(&self) -> roqoqo::devices::GenericDevice {
-        match self {
-            SimulatorDevice::QRydDevice(x) => x.to_generic_device(),
-            SimulatorDevice::TweezerDevice(x) => x.to_generic_device(),
-        }
-    }
-}
-
-impl From<FirstDevice> for SimulatorDevice {
-    fn from(input: FirstDevice) -> Self {
-        Self::QRydDevice(QRydDevice::FirstDevice(input))
-    }
-}
-
-impl From<TweezerDevice> for SimulatorDevice {
-    fn from(input: TweezerDevice) -> Self {
-        Self::TweezerDevice(input)
-    }
-}
+use crate::TweezerDevice;
 
 /// QRyd simulator backend
 ///
 /// A QRyd simulator simulates the action of each operation in a circuit on a quantum register.
 /// The underlying simulator uses the QuEST library.
 /// Although the underlying simulator supports arbitrary unitary gates, the QRyd simulator only
-/// allows operations that are available on a device model of a QRyd device (stored in a [crate::QRydDevice]).
+/// allows operations that are available on a device model of a QRyd device (stored in a [crate::TweezerDevice]).
 /// This limitation is introduced by design to check the compatability of circuits with a model of the QRyd hardware.
 /// For unrestricted simulations use the backend simulator of the roqoqo-quest crate.
 ///
@@ -156,19 +33,19 @@ impl From<TweezerDevice> for SimulatorDevice {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SimulatorBackend {
     /// Device representing the model of a QRyd device.
-    pub device: SimulatorDevice,
+    pub device: TweezerDevice,
     /// The number of qubits allocated by the simulator.
     pub number_qubits: usize,
 }
 
 impl SimulatorBackend {
-    /// Creates a new QRyd simulator backend.
+    /// Creates a new QRyd SimulatorBackend.
     ///
     /// # Arguments
     ///
-    /// `device` - The QRyd device used for the simulation.
+    /// `device` - The TweezerDevice used for the simulation.
     /// `number_qubits` - The number of qubits the simulator should use. Defaults to `device.number_qubits()`.
-    pub fn new(device: SimulatorDevice, number_qubits: Option<usize>) -> Self {
+    pub fn new(device: TweezerDevice, number_qubits: Option<usize>) -> Self {
         Self {
             device: device.clone(),
             number_qubits: number_qubits.unwrap_or(device.number_qubits()),

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -357,7 +357,11 @@ impl TweezerDevice {
     ///
     /// * `name` - The name of the new Layout.
     /// * `with_trivial_map` - Whether the qubit -> tweezer mapping should be trivially populated. Defaults to true.
-    pub fn switch_layout(&mut self, name: &str, with_trivial_map: Option<bool>) -> Result<(), RoqoqoBackendError> {
+    pub fn switch_layout(
+        &mut self,
+        name: &str,
+        with_trivial_map: Option<bool>,
+    ) -> Result<(), RoqoqoBackendError> {
         if !self.layout_register.keys().contains(&name.to_string()) {
             return Err(RoqoqoBackendError::GenericError {
                 msg: format!(

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -347,9 +347,9 @@ impl TweezerDevice {
         Ok(())
     }
 
-    /// Change the current Layout.
+    /// Switch to a different pre-defined Layout.
     ///
-    /// It is updated only if the new Layout is present in the device's
+    /// It is updated only if the given Layout name is present in the device's
     /// Layout register. If the qubit -> tweezer mapping is empty, it is
     /// trivially populated by default.
     ///

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -1233,7 +1233,10 @@ impl Device for TweezerDevice {
 
     fn number_qubits(&self) -> usize {
         if let Some(map) = &self.qubit_to_tweezer {
-            return map.keys().len();
+            if map.is_empty() {
+                return 0;
+            }
+            return *map.keys().max().unwrap_or(&0) + 1;
         }
         0
     }

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -899,9 +899,23 @@ impl TweezerDevice {
     /// # Returns
     ///
     /// * `usize` - The number of tweezer positions in the device.
-    pub fn number_tweezer_positions(&self) -> Result<usize, RoqoqoBackendError> {
+    /// * `layout_name` - The name of the layout to reference. Defaults to the current layout.
+    pub fn number_tweezer_positions(
+        &self,
+        layout_name: Option<String>,
+    ) -> Result<usize, RoqoqoBackendError> {
         let mut set_tweezer_indices: HashSet<usize> = HashSet::new();
-        let tweezer_info = self.get_current_layout_info()?;
+        let tweezer_info = if let Some(layout_name) = layout_name {
+            if let Some(tw) = self.layout_register.get(&layout_name) {
+                tw
+            } else {
+                return Err(RoqoqoBackendError::GenericError {
+                    msg: "The given layout name is not present in the layout register.".to_string(),
+                });
+            }
+        } else {
+            self.get_current_layout_info()?
+        };
         for single_qubit_gate_struct in &tweezer_info.tweezer_single_qubit_gate_times {
             for tw_id in single_qubit_gate_struct.1.keys() {
                 set_tweezer_indices.insert(*tw_id);

--- a/roqoqo-qryd/tests/integration/simulator_backend.rs
+++ b/roqoqo-qryd/tests/integration/simulator_backend.rs
@@ -10,30 +10,10 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ndarray::{array, Array2};
 use roqoqo::prelude::*;
 use roqoqo::{operations::*, Circuit};
-use roqoqo_qryd::qryd_devices::FirstDevice;
 use roqoqo_qryd::{SimulatorBackend, TweezerDevice};
 use roqoqo_test::prepare_monte_carlo_gate_test;
-
-/// Test SimulatorBackend initialization with FirstDevice.
-#[test]
-fn test_init_backend_fd() {
-    let device = FirstDevice::new(
-        2,
-        2,
-        &[1, 1],
-        3.0,
-        array![[0.0, 1.0], [0.0, 1.0]],
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap();
-    let _backend = SimulatorBackend::new(device.into(), None);
-}
 
 /// Test SimulatorBackend initialization with TweezerDevice.
 #[test]
@@ -54,7 +34,7 @@ fn test_init_backend_tw() {
         .unwrap();
     device.switch_layout("square", None).unwrap();
 
-    let _backend = SimulatorBackend::new(device.into(), None);
+    let _backend = SimulatorBackend::new(device, None);
 }
 
 #[test]
@@ -63,90 +43,31 @@ fn test_to_qryd_json() {}
 /// Test SimulatorBackend standard derived traits (Debug, Clone, PartialEq)
 #[test]
 fn test_simple_traits() {
-    let layout: Array2<f64> = array![[0.0, 1.0], [0.0, 1.0]];
-    let device_fd = FirstDevice::new(
-        2,
-        2,
-        &[1, 1],
-        3.0,
-        array![[0.0, 1.0], [0.0, 1.0]],
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap()
-    .add_layout(1, layout.clone())
-    .unwrap();
-    let backend_fd = SimulatorBackend::new(device_fd.clone().into(), None);
     let mut device_tw = TweezerDevice::new(None, None, None);
     device_tw.add_layout("test").unwrap();
     device_tw.add_layout("test2").unwrap();
-    let backend_tw = SimulatorBackend::new(device_tw.clone().into(), None);
+    let backend_tw = SimulatorBackend::new(device_tw.clone(), None);
 
     // Test Debug trait
     assert_eq!(
-        format!("{:?}", backend_fd),
-        format!(
-            "SimulatorBackend {{ device: QRydDevice(FirstDevice({:?})), number_qubits: 2 }}",
-            device_fd
-        )
-    );
-    assert_eq!(
         format!("{:?}", backend_tw),
         format!(
-            "SimulatorBackend {{ device: TweezerDevice({:?}), number_qubits: 0 }}",
+            "SimulatorBackend {{ device: {:?}, number_qubits: 0 }}",
             device_tw
         )
     );
 
     // Test Clone trait
-    assert_eq!(backend_fd.clone(), backend_fd);
     assert_eq!(backend_tw.clone(), backend_tw);
 
     // Test PartialEq trait
-    let device_0 = FirstDevice::new(
-        2,
-        2,
-        &[1, 1],
-        3.0,
-        array![[0.0, 1.0], [0.0, 1.0]],
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap()
-    .add_layout(1, layout.clone())
-    .unwrap();
-    let backend_0 = SimulatorBackend::new(device_0.into(), None);
-    let device_1 = FirstDevice::new(
-        2,
-        2,
-        &[1, 1],
-        2.0,
-        array![[0.0, 1.0], [0.0, 1.0]],
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap()
-    .add_layout(1, layout)
-    .unwrap();
-    let backend_1 = SimulatorBackend::new(device_1.into(), None);
-    assert!(backend_0 == backend_fd);
-    assert!(backend_fd == backend_0);
-    assert!(backend_1 != backend_fd);
-    assert!(backend_fd != backend_1);
-
     let mut device_0 = TweezerDevice::new(None, None, None);
     device_0.add_layout("test").unwrap();
     device_0.add_layout("test2").unwrap();
     let mut device_1 = TweezerDevice::new(None, None, None);
     device_1.add_layout("different").unwrap();
-    let backend_0 = SimulatorBackend::new(device_0.into(), None);
-    let backend_1 = SimulatorBackend::new(device_1.into(), None);
+    let backend_0 = SimulatorBackend::new(device_0, None);
+    let backend_1 = SimulatorBackend::new(device_1, None);
     assert!(backend_0 == backend_tw);
     assert!(backend_tw == backend_0);
     assert!(backend_1 != backend_tw);
@@ -156,24 +77,6 @@ fn test_simple_traits() {
 /// Test .run_circuit() with a simple circuit
 #[test]
 fn test_simple_circuit() {
-    let layout: Array2<f64> = array![[0.0, 1.0], [0.0, 1.0]];
-    let mut device = FirstDevice::new(
-        2,
-        2,
-        &[1, 1],
-        3.0,
-        array![[0.0, 1.0], [0.0, 1.0]],
-        None,
-        None,
-        None,
-        None,
-    )
-    .unwrap()
-    .add_layout(1, layout)
-    .unwrap();
-    device.switch_layout(&1).unwrap();
-    let backend_fd = SimulatorBackend::new(device.into(), None);
-
     let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("test").unwrap();
     device
@@ -183,30 +86,22 @@ fn test_simple_circuit() {
         .set_tweezer_single_qubit_gate_time("RotateX", 1, 1.0, Some("test".to_string()))
         .unwrap();
     device.switch_layout("test", None).unwrap();
-    let backend_tw = SimulatorBackend::new(device.into(), None);
+    let backend_tw = SimulatorBackend::new(device, None);
 
     let mut circuit = Circuit::new();
     circuit += DefinitionBit::new("ro".to_string(), 2, true);
     circuit += RotateX::new(0, std::f64::consts::FRAC_PI_2.into());
     circuit += RotateX::new(1, std::f64::consts::FRAC_PI_2.into());
     circuit += PragmaRepeatedMeasurement::new("ro".to_string(), 20, None);
-    let (bit_registers_fd, _float_registers, _complex_registers) =
-        backend_fd.run_circuit(&circuit).unwrap();
     let (bit_registers_tw, _float_registers, _complex_registers) =
         backend_tw.run_circuit(&circuit).unwrap();
 
-    assert!(bit_registers_fd.contains_key("ro"));
     assert!(bit_registers_tw.contains_key("ro"));
 
-    let out_reg_fd = bit_registers_fd.get("ro").unwrap();
     let out_reg_tw = bit_registers_tw.get("ro").unwrap();
 
-    assert_eq!(out_reg_fd.len(), 20);
     assert_eq!(out_reg_tw.len(), 20);
 
-    for reg in out_reg_fd.iter() {
-        assert_eq!(reg.len(), 2);
-    }
     for reg in out_reg_tw.iter() {
         assert_eq!(reg.len(), 2);
     }
@@ -222,8 +117,20 @@ fn test_measurement() {
         vec![RotateY::new(0, std::f64::consts::FRAC_PI_2.into()).into()];
     let (measurement, exp_vals) =
         prepare_monte_carlo_gate_test(gate, preparation_gates, basis_rotation_gates, None, 1, 200);
-    let device = FirstDevice::new(1, 1, &[1], 3.0, array![[0.0],], None, None, None, None).unwrap();
-    let backend = SimulatorBackend::new(device.into(), None);
+    let mut device = TweezerDevice::new(None, None, None);
+    device.add_layout("test").unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("RotateX", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("RotateY", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("PhaseShiftState1", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device.switch_layout("test", None).unwrap();
+
+    let backend = SimulatorBackend::new(device, None);
     let measured_exp_vals = backend.run_measurement(&measurement).unwrap().unwrap();
     for (key, val) in exp_vals.iter() {
         assert!((val - measured_exp_vals.get(key).unwrap()).abs() < 1.0);
@@ -247,9 +154,22 @@ fn test_full_simple_gate() {
     let (measurement, exp_vals) =
         prepare_monte_carlo_gate_test(gate, preparation_gates, basis_rotation_gates, None, 5, 200);
 
-    let device =
-        FirstDevice::new(1, 1, &[1], 3.0, array![[0.0,],], None, None, None, None).unwrap();
-    let backend = SimulatorBackend::new(device.into(), None);
+    let mut device = TweezerDevice::new(None, None, None);
+    device.add_layout("test").unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("RotateX", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("RotateY", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("PhaseShiftState1", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time("PauliZ", 0, 1.0, Some("test".to_string()))
+        .unwrap();
+    device.switch_layout("test", None).unwrap();
+    let backend = SimulatorBackend::new(device, None);
     let measured_exp_vals = backend.run_measurement(&measurement).unwrap().unwrap();
     for (key, val) in exp_vals.iter() {
         assert!((val - measured_exp_vals.get(key).unwrap()).abs() < 1.0);

--- a/roqoqo-qryd/tests/integration/simulator_backend.rs
+++ b/roqoqo-qryd/tests/integration/simulator_backend.rs
@@ -153,7 +153,7 @@ fn test_simple_traits() {
     assert!(backend_tw != backend_1);
 }
 
-/// Test .run_circuit() with a simple circuit 
+/// Test .run_circuit() with a simple circuit
 #[test]
 fn test_simple_circuit() {
     let layout: Array2<f64> = array![[0.0, 1.0], [0.0, 1.0]];

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -192,14 +192,46 @@ fn test_layouts() {
     assert_eq!(device.current_layout, Some("default".to_string()));
     assert!(device.qubit_to_tweezer.is_none());
 
-    device.switch_layout("Test").unwrap();
+    device.switch_layout("Test", None).unwrap();
     assert_eq!(device.current_layout, Some("Test".to_string()));
     assert!(device.qubit_to_tweezer.is_some());
     assert_eq!(device.qubit_to_tweezer.clone().unwrap().len(), 4);
 
-    assert!(device.switch_layout("Error").is_err());
+    assert!(device.switch_layout("Error", None).is_err());
 
     assert!(device.available_layouts().contains(&"Test"));
+
+    device.add_layout("test_trivial_population").unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time(
+            "RotateZ",
+            1,
+            0.23,
+            Some("test_trivial_population".to_string()),
+        )
+        .unwrap();
+    device
+        .set_tweezer_single_qubit_gate_time(
+            "RotateY",
+            2,
+            0.23,
+            Some("test_trivial_population".to_string()),
+        )
+        .unwrap();
+    device
+        .switch_layout("test_trivial_population", Some(false))
+        .unwrap();
+
+    assert!(device.qubit_to_tweezer.is_none());
+
+    device
+        .switch_layout("test_trivial_population", Some(true))
+        .unwrap();
+
+    assert_eq!(
+        device.qubit_to_tweezer.unwrap(),
+        HashMap::from([(0, 0), (1, 1), (2, 2)])
+    );
 }
 
 // Test TweezerDevice add_qubit_tweezer_mapping(), get_tweezer_from_qubit() methods
@@ -303,7 +335,7 @@ fn test_allowed_tweezer_shifts_row() {
     device
         .set_tweezer_single_qubit_gate_time("PauliX", 2, 0.0, Some("OtherLayout".to_string()))
         .unwrap();
-    device.switch_layout("OtherLayout").unwrap();
+    device.switch_layout("OtherLayout", None).unwrap();
 
     assert!(device
         .set_allowed_tweezer_shifts(&0, &[&[1], &[2]], Some("OtherLayout".to_string()))

--- a/roqoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/roqoqo-qryd/tests/integration/tweezer_devices.rs
@@ -483,8 +483,17 @@ fn test_number_qubits() {
 fn test_number_tweezer_positions() {
     let mut device = TweezerDevice::new(None, None, None);
     device.add_layout("default").unwrap();
+    device.add_layout("empty").unwrap();
 
-    assert!(device.number_tweezer_positions().is_err());
+    assert_eq!(
+        device.number_tweezer_positions(Some("empty".to_string())),
+        Ok(0)
+    );
+
+    assert!(device.number_tweezer_positions(None).is_err());
+    assert!(device
+        .number_tweezer_positions(Some("error".to_string()))
+        .is_err());
 
     device.current_layout = Some("default".to_string());
     device
@@ -494,13 +503,13 @@ fn test_number_tweezer_positions() {
         .set_tweezer_two_qubit_gate_time("CNOT", 1, 7, 0.23, None)
         .unwrap();
     device
-        .set_tweezer_three_qubit_gate_time("Tottoli", 2, 9, 13, 0.34, None)
+        .set_tweezer_three_qubit_gate_time("Toffoli", 2, 9, 13, 0.34, None)
         .unwrap();
     device
         .set_tweezer_multi_qubit_gate_time("MultiQubitZZ", &[1, 12, 5], 0.34, None)
         .unwrap();
 
-    assert_eq!(device.number_tweezer_positions(), Ok(8));
+    assert_eq!(device.number_tweezer_positions(None), Ok(8));
 }
 
 /// Test TweezerDevice to_generic_device() method


### PR DESCRIPTION
* Added `TweezerDevice.get_qubit_to_tweezer_mapping()`
* Added `with_trivial_map` parameter to `TweezerDevice.switch_layout()`
* Added `layout_name` parameter to `TweezerDevice.number_tweezer_positions()`
* Added `TweezerDevice` support for `SimulatorBackend`
* Added `number_qubits` parameter to `SimulatorBackend`
* Modified `TweezerDevice.number_qubits()` back to index-based implementation
* Dropped `FirstDevice` support for `SimulatorBackend`