### PR TITLE
Available Gates Names, Native Gates Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Tracks qoqo-qryd changes after 0.5
 * Modified the native gate set whitelist to be public
 * Fixed `TweezerDevice.to_json()` to support the whole whitelist
 * Updated dependencies addressing security advisory
+* Update to Qoqo 1.10
 
 # 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Tracks qoqo-qryd changes after 0.5
 
-# 0.14.1
+# 0.15.0
 
 * Added `TweezerDevice.get_available_gates_names()`
 * Added ControlledPhaseShift and ControlledPauliZ to the native gate set whitelist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ Tracks qoqo-qryd changes after 0.5
 # 0.14.1
 
 * Added `TweezerDevice.get_available_gates_names()`
+* Added ControlledPhaseShift and ControlledPauliZ to the native gate set whitelist
 * Modified the native gate set whitelist to be public
 * Fixed `TweezerDevice.to_json()` to support the whole whitelist
+* Updated dependencies addressing security advisory
 
 # 0.14.0
 
-* Added native gate set whitelist for `TweezerDevice` tweezer setters.
+* Added native gate set whitelist for `TweezerDevice` tweezer setters: RotateZ, RotateX, RotateXY, PhaseShiftState0, PhaseShiftState1, PhaseShiftedControlledZ, PhaseShiftedControlledPhase, ControlledControlledPauliZ and ControlledControlledPhaseShift
 
 # 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Tracks qoqo-qryd changes after 0.5
 
 # 0.14.1
 
-* Added `TweezerDevice.get_supported_gate_names()`
+* Added `TweezerDevice.get_available_gates_names()`
 
 # 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tracks qoqo-qryd changes after 0.5
 
+# 0.14.1
+
+* Added `TweezerDevice.get_supported_gate_names()`
+
 # 0.14.0
 
 * Added gate set whitelist for `TweezerDevice` tweezer setters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Tracks qoqo-qryd changes after 0.5
 # 0.14.1
 
 * Added `TweezerDevice.get_available_gates_names()`
+* Modified the native gate set whitelist to be public
+* Fixed `TweezerDevice.to_json()` to support the whole whitelist
 
 # 0.14.0
 
-* Added gate set whitelist for `TweezerDevice` tweezer setters.
+* Added native gate set whitelist for `TweezerDevice` tweezer setters.
 
 # 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Tracks qoqo-qryd changes after 0.5
 
 * Added `TweezerDevice.get_available_gates_names()`
 * Added ControlledPhaseShift and ControlledPauliZ to the native gate set whitelist
+* Added `TweezerDevice.from_json()` gate set validity check
 * Modified the native gate set whitelist to be public
-* Fixed `TweezerDevice.to_json()` to support the whole whitelist
+* Fixed `TweezerDevice.to_json()` gate set validity check
 * Updated dependencies addressing security advisory
 * Update to Qoqo 1.10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 
 [[package]]
 name = "cfg-if"
@@ -309,9 +309,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -443,9 +443,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode",
  "mockito",
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode",
  "bitvec",
@@ -1682,9 +1682,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1729,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1742,15 +1742,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -1362,9 +1362,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "struqture"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0c8e01ccb1eb5704756651126b09a0eb276fe3d018e87f6490773cefb38359"
+checksum = "b5e6a6fae203fb8098042ab51364cf5ff79020312e68b63038371d627029ab08"
 dependencies = [
  "itertools 0.12.1",
  "ndarray",
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b138454a27864ea7ca9a22eaf0351270c78cb329961e5d46395cc9bcac31b3"
+checksum = "bd549b80a7e8a929b9125c37c8ec8f74916df3ed2fbc427462ee93812c1f450e"
 dependencies = [
  "bincode",
  "num-complex",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "struqture-py-macros"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9274be85d19e94e55fba30b59ef862d2b11778b099a61449cb381c8965644c79"
+checksum = "3215f75379ad75b4847b3166e5fd39de65ae2723a9cdd382ad92966925a8f48e"
 dependencies = [
  "num-complex",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo-qryd"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bincode",
  "mockito",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "roqoqo-qryd"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bincode",
  "bitvec",

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo-qryd"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -44,7 +44,7 @@ qoqo_calculator_pyo3 = { version = "1.1", default-features = false }
 qoqo = { version = "1.10", default-features = false }
 roqoqo = { version = "1.10", features = ["serialize"] }
 
-roqoqo-qryd = { version = "0.14", path = "../roqoqo-qryd", default-features = false, features = [
+roqoqo-qryd = { version = "0.15", path = "../roqoqo-qryd", default-features = false, features = [
     "web-api",
 ] }
 

--- a/qoqo-qryd/Cargo.toml
+++ b/qoqo-qryd/Cargo.toml
@@ -41,8 +41,8 @@ numpy = "0.20"
 
 qoqo_calculator = { version = "1.1" }
 qoqo_calculator_pyo3 = { version = "1.1", default-features = false }
-qoqo = { version = "1.9", default-features = false }
-roqoqo = { version = "1.9", features = ["serialize"] }
+qoqo = { version = "1.10", default-features = false }
+roqoqo = { version = "1.10", features = ["serialize"] }
 
 roqoqo-qryd = { version = "0.14", path = "../roqoqo-qryd", default-features = false, features = [
     "web-api",

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = ['numpy', 'qoqo>=1.9', 'qoqo_calculator_pyo3>=1.1']
 license = { text = "Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause" }
 maintainers = [

--- a/qoqo-qryd/pyproject.toml
+++ b/qoqo-qryd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qoqo_qryd"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = ['numpy', 'qoqo>=1.9', 'qoqo_calculator_pyo3>=1.1']
 license = { text = "Apache-2.0 AND Apache-2.0 with LLVM-exception AND MIT AND Unicode-DFS-2016 AND BSD-2-Clause AND BSD-3-CLause" }
 maintainers = [

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -18845,7 +18845,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.14.1
+qoqo-qryd 0.15.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -22588,7 +22588,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.14.1
+roqoqo-qryd 0.15.0
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -2196,7 +2196,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-cc 1.0.89
+cc 1.0.90
 https://github.com/rust-lang/cc-rs
 by Alex Crichton <alex@alexcrichton.com>
 A build-time dependency for Cargo build scripts to assist in invoking the native
@@ -27453,7 +27453,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ====================================================
-struqture 1.6.0
+struqture 1.6.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
@@ -27664,13 +27664,13 @@ LICENSE:
 
 
 ====================================================
-struqture-py 1.6.0
+struqture-py 1.6.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Python interface of struqture, the HQS tool for representing operators, Hamiltonians and open systems.
 License: Apache-2.0
 
 ====================================================
-struqture-py-macros 1.6.0
+struqture-py-macros 1.6.1
 by HQS Quantum Simulations <info@quantumsimulations.de>
 Macros for struqture-py crate.
 License: Apache-2.0

--- a/qoqo-qryd/qoqo_qryd/DEPENDENCIES
+++ b/qoqo-qryd/qoqo_qryd/DEPENDENCIES
@@ -2196,7 +2196,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-cc 1.0.88
+cc 1.0.89
 https://github.com/rust-lang/cc-rs
 by Alex Crichton <alex@alexcrichton.com>
 A build-time dependency for Cargo build scripts to assist in invoking the native
@@ -7831,7 +7831,7 @@ SOFTWARE.
 
 
 ====================================================
-http 0.2.11
+http 0.2.12
 https://github.com/hyperium/http
 by Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>
 A set of types for representing HTTP requests and responses.
@@ -9126,7 +9126,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-indexmap 2.2.4
+indexmap 2.2.5
 https://github.com/indexmap-rs/indexmap
 by 
 A hash table with consistent order and fast iteration.
@@ -10714,7 +10714,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-js-sys 0.3.68
+js-sys 0.3.69
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bindings for all JS global objects and functions in all JS environments like
@@ -12730,7 +12730,7 @@ SOFTWARE.
 
 
 ====================================================
-mio 0.8.10
+mio 0.8.11
 https://github.com/tokio-rs/mio
 by Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>
 Lightweight non-blocking I/O.
@@ -18845,7 +18845,7 @@ LICENSE:
 
 
 ====================================================
-qoqo-qryd 0.14.0
+qoqo-qryd 0.14.1
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd backend for qoqo quantum computing toolkit
@@ -21441,7 +21441,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-regex-automata 0.4.5
+regex-automata 0.4.6
 https://github.com/rust-lang/regex/tree/master/regex-automata
 by The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 Automata construction and matching using regular expressions.
@@ -22588,7 +22588,7 @@ LICENSE:
 
 
 ====================================================
-roqoqo-qryd 0.14.0
+roqoqo-qryd 0.14.1
 https://github.com/HQSquantumsimulations/qoqo_qryd
 by HQS Quantum Simulations <info@quantumsimulations.de>
 QRyd interface for roqoqo rust quantum computing toolkit
@@ -32247,7 +32247,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen 0.2.91
+wasm-bindgen 0.2.92
 https://rustwasm.github.io/
 by The wasm-bindgen Developers
 Easy support for interacting between JS and Rust.
@@ -32489,7 +32489,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-backend 0.2.91
+wasm-bindgen-backend 0.2.92
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Backend code generation of the wasm-bindgen tool
@@ -32731,7 +32731,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-futures 0.4.41
+wasm-bindgen-futures 0.4.42
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Bridging the gap between Rust Futures and JavaScript Promises
@@ -32972,7 +32972,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro 0.2.91
+wasm-bindgen-macro 0.2.92
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
@@ -33214,7 +33214,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-macro-support 0.2.91
+wasm-bindgen-macro-support 0.2.92
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate
@@ -33456,7 +33456,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-wasm-bindgen-shared 0.2.91
+wasm-bindgen-shared 0.2.92
 https://rustwasm.github.io/wasm-bindgen/
 by The wasm-bindgen Developers
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
@@ -33699,7 +33699,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ====================================================
-web-sys 0.3.68
+web-sys 0.3.69
 https://rustwasm.github.io/wasm-bindgen/web-sys/index.html
 by The wasm-bindgen Developers
 Bindings for all Web APIs, a procedurally generated crate from WebIDL

--- a/qoqo-qryd/src/tweezer_devices.rs
+++ b/qoqo-qryd/src/tweezer_devices.rs
@@ -222,6 +222,23 @@ impl TweezerDeviceWrapper {
         })
     }
 
+    /// Get the names of the available gates in the given layout.
+    ///
+    /// Args:
+    ///     layout_name (Optional[str]): The name of the layout. Defaults to the current Layout.
+    ///
+    /// Returns:
+    ///     list[str]: List of the names of the available gates in the given layout.
+    ///
+    /// Raises:
+    ///     ValueError: No layout name provided and no current layout set.
+    #[pyo3(text_signature = "(layout_name, /)")]
+    pub fn get_available_gates_names(&self, layout_name: Option<String>) -> PyResult<Vec<&str>> {
+        self.internal
+            .get_available_gates_names(layout_name)
+            .map_err(|err| PyValueError::new_err(format!("{:}", err)))
+    }
+
     /// Deactivate the given qubit in the device.
     ///
     /// Args:
@@ -746,6 +763,23 @@ impl TweezerMutableDeviceWrapper {
                 .as_ref()
                 .map(|mapping| mapping.into_py_dict(py).into())
         })
+    }
+
+    /// Get the names of the available gates in the given layout.
+    ///
+    /// Args:
+    ///     layout_name (Optional[str]): The name of the layout. Defaults to the current Layout.
+    ///
+    /// Returns:
+    ///     list[str]: List of the names of the available gates in the given layout.
+    ///
+    /// Raises:
+    ///     ValueError: No layout name provided and no current layout set.
+    #[pyo3(text_signature = "(layout_name, /)")]
+    pub fn get_available_gates_names(&self, layout_name: Option<String>) -> PyResult<Vec<&str>> {
+        self.internal
+            .get_available_gates_names(layout_name)
+            .map_err(|err| PyValueError::new_err(format!("{:}", err)))
     }
 
     /// Deactivate the given qubit in the device.

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -977,8 +977,11 @@ fn test_to_from_json() {
         assert_eq!(
             serialised_empty.unwrap_err().to_string(),
             PyValueError::new_err(
-                "The device does not have valid QRyd gates available. ".to_owned() +
-                "The valid gates are RotateXY, PhaseShiftState1 and PhaseShiftedControlledPhase.",
+                "The device does not support valid gates in a layout. ".to_owned() +
+                "The valid gates are: RotateZ, RotateX, RotateXY, PhaseShiftState0, " +
+                "PhaseShiftState1, ControlledPhaseShift, ControlledPauliZ, " +
+                "PhaseShiftedControlledZ, PhaseShiftedControlledPhase, ControlledControlledPauliZ, " +
+                "ControlledControlledPhaseShift."
             ).to_string()
         );
     });

--- a/qoqo-qryd/tests/integration/tweezer_devices.rs
+++ b/qoqo-qryd/tests/integration/tweezer_devices.rs
@@ -984,6 +984,26 @@ fn test_to_from_json() {
                 "ControlledControlledPhaseShift."
             ).to_string()
         );
+
+        let serialized_mut = device_mut.call_method0("to_json").unwrap();
+        let str_serialized_device_with_wrong_gate = serialized_mut
+            .extract::<String>()
+            .unwrap()
+            .replace("PhaseShiftedControlledPhase", "CNOT");
+        let device = device_type_mut.call0().unwrap();
+        let deserialized_with_wrong_gate =
+            device.call_method1("from_json", (str_serialized_device_with_wrong_gate,));
+        assert!(deserialized_with_wrong_gate.is_err());
+        assert_eq!(
+            deserialized_with_wrong_gate.unwrap_err().to_string(),
+            PyValueError::new_err(
+                "The device does not support valid gates in a layout. ".to_owned() +
+                "The valid gates are: RotateZ, RotateX, RotateXY, PhaseShiftState0, " +
+                "PhaseShiftState1, ControlledPhaseShift, ControlledPauliZ, " +
+                "PhaseShiftedControlledZ, PhaseShiftedControlledPhase, ControlledControlledPauliZ, " +
+                "ControlledControlledPhaseShift."
+            ).to_string()
+        );
     });
 }
 

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -38,15 +38,15 @@ bitvec = { version = "1.0", optional = true }
 hex = { version = "0.4", optional = true }
 itertools = "0.11"
 
-roqoqo = { version = "1.9", features = ["serialize"] }
-roqoqo-derive = { version = "1.9" }
+roqoqo = { version = "1.10", features = ["serialize"] }
+roqoqo-derive = { version = "1.10" }
 roqoqo-quest = { version = "0.11", default-features = false, optional = true }
 qoqo_calculator = { version = "1.1" }
 
 [dev-dependencies]
 test-case = "3.0"
 serde_test = { version = "1.0" }
-roqoqo-test = { version = "1.9" }
+roqoqo-test = { version = "1.10" }
 mockito = { version = "1.2", default-features = false }
 
 [features]

--- a/roqoqo-qryd/Cargo.toml
+++ b/roqoqo-qryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roqoqo-qryd"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -404,7 +404,7 @@ impl TweezerDevice {
     ///
     /// # Returns:
     ///
-    /// * `Vec<&String>` - The vector of all available Layout names.
+    /// * `Vec<&str>` - The vector of all available Layout names.
     pub fn available_layouts(&self) -> Vec<&str> {
         self.layout_register
             .keys()
@@ -837,6 +837,51 @@ impl TweezerDevice {
                 msg: "The device qubit -> tweezer mapping is empty.".to_string(),
             })
         }
+    }
+
+    /// Get the names of the available gates in the given layout.
+    ///
+    /// # Arguments
+    ///
+    /// * `layout` - The name of the layout. Defaults to the current Layout.
+    ///
+    /// # Returns
+    ///
+    /// * `Vec<&str>` - Vector of the names of the available gates in the given layout.
+    /// * `Err(RoqoqoBackendError)` - The given layout name is not present in the layout register.
+    pub fn get_available_gates_names(
+        &self,
+        layout_name: Option<String>,
+    ) -> Result<Vec<&str>, RoqoqoBackendError> {
+        let layout_name = layout_name
+            .or_else(|| self.current_layout.as_ref().map(|s| s.to_string()))
+            .ok_or_else(|| RoqoqoBackendError::GenericError {
+                msg: "No layout name provided and no current layout set.".to_string(),
+            })?;
+
+        let mut names: HashSet<&str> = HashSet::new();
+        if let Some(info) = self.layout_register.get(&layout_name) {
+            let sqg = &info.tweezer_single_qubit_gate_times;
+            for name in sqg.keys().by_ref() {
+                names.insert(name);
+            }
+
+            let dqg = &info.tweezer_two_qubit_gate_times;
+            for name in dqg.keys().by_ref() {
+                names.insert(name);
+            }
+
+            let tqg = &info.tweezer_three_qubit_gate_times;
+            for name in tqg.keys().by_ref() {
+                names.insert(name);
+            }
+
+            let mqg = &info.tweezer_multi_qubit_gate_times;
+            for name in mqg.keys().by_ref() {
+                names.insert(name);
+            }
+        }
+        Ok(names.into_iter().collect())
     }
 
     /// Deactivate the given qubit in the device.

--- a/roqoqo-qryd/src/tweezer_devices.rs
+++ b/roqoqo-qryd/src/tweezer_devices.rs
@@ -35,20 +35,31 @@ use crate::{
     PragmaSwitchDeviceLayout,
 };
 
-static ALLOWED_NATIVE_SINGLE_QUBIT_GATES: [&str; 5] = [
+/// Native single-qubit gates allowed by the QRyd backend.
+pub static ALLOWED_NATIVE_SINGLE_QUBIT_GATES: [&str; 5] = [
     "RotateZ",
     "RotateX",
     "RotateXY",
     "PhaseShiftState0",
     "PhaseShiftState1",
 ];
-static ALLOWED_NATIVE_TWO_QUBIT_GATES: [&str; 2] =
-    ["PhaseShiftedControlledZ", "PhaseShiftedControlledPhase"];
-static ALLOWED_NATIVE_THREE_QUBIT_GATES: [&str; 2] = [
+
+/// Native two-qubit gates allowed by the QRyd backend.
+pub static ALLOWED_NATIVE_TWO_QUBIT_GATES: [&str; 4] = [
+    "ControlledPhaseShift",
+    "ControlledPauliZ",
+    "PhaseShiftedControlledZ",
+    "PhaseShiftedControlledPhase",
+];
+
+/// Native three-qubit gates allowed by the QRyd backend.
+pub static ALLOWED_NATIVE_THREE_QUBIT_GATES: [&str; 2] = [
     "ControlledControlledPauliZ",
     "ControlledControlledPhaseShift",
 ];
-static ALLOWED_NATIVE_MULTI_QUBIT_GATES: [&str; 0] = [];
+
+/// Native multi-qubit gates allowed by the QRyd backend.
+pub static ALLOWED_NATIVE_MULTI_QUBIT_GATES: [&str; 0] = [];
 
 /// Tweezer Device
 ///


### PR DESCRIPTION
* Added `TweezerDevice.get_available_gates_names()`
* Added ControlledPhaseShift and ControlledPauliZ to the native gate set whitelist
* Added `TweezerDevice.from_json()` gate set validity check
* Modified the native gate set whitelist to be public
* Fixed `TweezerDevice.to_json()` gate set validity check
* Updated dependencies addressing security advisory
* Update to Qoqo 1.10